### PR TITLE
Pin third-party dependency versions and fix CoACD API update

### DIFF
--- a/Source/URLab/Public/Utils/MeshUtils.h
+++ b/Source/URLab/Public/Utils/MeshUtils.h
@@ -73,7 +73,7 @@ int SaveMeshAsOBJComplex(const FString& FilePath, const Chaos::TArrayCollectionA
     CoACD_Mesh inputMesh = CoacdInterface::ConvertToCoACDMesh(Vertices, Indices);
 
     CoACD_MeshArray result = CoACD_run(inputMesh, Threshold, -1, preprocess_auto, 30, 1000, 20, 150, 3, false, true, false, 100,
-                                       false, 0.01, apx_ch, 0);
+                                       false, 0.01, apx_ch, 0, false);
     int MeshCount = result.meshes_count;
 
     UE_LOG(LogURLab, Log, TEXT("CoACD: %d convex hulls created (threshold=%.3f)"), result.meshes_count, Threshold);

--- a/third_party/CoACD/build.ps1
+++ b/third_party/CoACD/build.ps1
@@ -14,10 +14,18 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
+$PinnedCommit = "c7436bf"  # Pin to tested commit (CDT include path fix + unbundled 3rd party support)
+
 $RepoDir = "src"
 if (-not (Test-Path $RepoDir)) {
-    Write-Host "Cloning CoACD..." -ForegroundColor Gray
+    Write-Host "Cloning CoACD (pinned: $PinnedCommit)..." -ForegroundColor Gray
     git clone https://github.com/SarahWeiii/CoACD $RepoDir
+    Push-Location $RepoDir
+    git checkout $PinnedCommit
+    Pop-Location
+} else {
+    Write-Host "CoACD source already exists at '$RepoDir'. Skipping clone." -ForegroundColor Yellow
+    Write-Host "  To rebuild from scratch, delete '$RepoDir/' and re-run." -ForegroundColor Yellow
 }
 
 Push-Location $RepoDir
@@ -27,7 +35,10 @@ if ($LASTEXITCODE -ne 0) { Write-Warning "Submodule update failed for CoACD" }
 
 Write-Host "Applying custom CoACD configuration..." -ForegroundColor Gray
 Copy-Item -Path "../../CoACD_custom/CMakeLists.txt" -Destination "." -Force
-Copy-Item -Path "../../CoACD_custom/cmake/*" -Destination "cmake/" -Recurse -Force
+if (Test-Path "../../CoACD_custom/cmake") {
+    if (-not (Test-Path "cmake")) { New-Item -ItemType Directory -Path "cmake" | Out-Null }
+    Copy-Item -Path "../../CoACD_custom/cmake/*" -Destination "cmake/" -Recurse -Force
+}
 
 if (-not (Test-Path "build")) { New-Item -ItemType Directory -Path "build" }
 cd build

--- a/third_party/CoACD/build.sh
+++ b/third_party/CoACD/build.sh
@@ -1,14 +1,32 @@
 #!/bin/bash
 INSTALL_DIR=${1:-"../install"}
 BUILD_TYPE=${2:-"Release"}
+PINNED_COMMIT="c7436bf"  # Pin to tested commit (CDT include path fix + unbundled 3rd party support)
 
 REPO_DIR="src"
 if [ ! -d "$REPO_DIR" ]; then
-    echo "Cloning CoACD..."
+    echo "Cloning CoACD (pinned: $PINNED_COMMIT)..."
     git clone https://github.com/SarahWeiii/CoACD "$REPO_DIR"
+    cd "$REPO_DIR"
+    git checkout "$PINNED_COMMIT"
+    cd ..
+else
+    echo "CoACD source already exists at '$REPO_DIR'. Skipping clone."
+    echo "  To rebuild from scratch, delete '$REPO_DIR/' and re-run."
 fi
 
 cd "$REPO_DIR"
+
+echo "Initializing submodules..."
+git submodule update --init --recursive
+
+echo "Applying custom CoACD configuration..."
+cp -f ../../CoACD_custom/CMakeLists.txt .
+if [ -d "../../CoACD_custom/cmake" ]; then
+    mkdir -p cmake
+    cp -rf ../../CoACD_custom/cmake/* cmake/
+fi
+
 mkdir -p build
 cd build
 
@@ -16,7 +34,7 @@ echo "Configuring CoACD..."
 cmake .. -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DWITH_3RD_PARTY_LIBS=ON
 
 echo "Building CoACD..."
-cmake --build . --config "$BUILD_TYPE"
+cmake --build . --config "$BUILD_TYPE" --target _coacd
 
 echo "Installing CoACD..."
 cmake --install . --config "$BUILD_TYPE"

--- a/third_party/MuJoCo/build.ps1
+++ b/third_party/MuJoCo/build.ps1
@@ -14,10 +14,18 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
+$PinnedCommit = "47264877"  # Pin to tested commit (MuJoCo 3.7.0 dev, polynomial stiffness/damping)
+
 $RepoDir = "src"
 if (-not (Test-Path $RepoDir)) {
-    Write-Host "Cloning MuJoCo..." -ForegroundColor Gray
+    Write-Host "Cloning MuJoCo (pinned: $PinnedCommit)..." -ForegroundColor Gray
     git clone https://github.com/google-deepmind/mujoco $RepoDir
+    Push-Location $RepoDir
+    git checkout $PinnedCommit
+    Pop-Location
+} else {
+    Write-Host "MuJoCo source already exists at '$RepoDir'. Skipping clone." -ForegroundColor Yellow
+    Write-Host "  To rebuild from scratch, delete '$RepoDir/' and re-run." -ForegroundColor Yellow
 }
 
 Push-Location $RepoDir

--- a/third_party/MuJoCo/build.sh
+++ b/third_party/MuJoCo/build.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 INSTALL_DIR=${1:-"../install"}
 BUILD_TYPE=${2:-"Release"}
+PINNED_COMMIT="47264877"  # Pin to tested commit (MuJoCo 3.7.0 dev, polynomial stiffness/damping)
 
 REPO_DIR="src"
 if [ ! -d "$REPO_DIR" ]; then
-    echo "Cloning MuJoCo..."
+    echo "Cloning MuJoCo (pinned: $PINNED_COMMIT)..."
     git clone https://github.com/google-deepmind/mujoco "$REPO_DIR"
+    cd "$REPO_DIR"
+    git checkout "$PINNED_COMMIT"
+    cd ..
+else
+    echo "MuJoCo source already exists at '$REPO_DIR'. Skipping clone."
+    echo "  To rebuild from scratch, delete '$REPO_DIR/' and re-run."
 fi
 
 cd "$REPO_DIR"
+
+echo "Initializing submodules..."
+git submodule update --init --recursive
+
 mkdir -p build
 cd build
 

--- a/third_party/libzmq/build.ps1
+++ b/third_party/libzmq/build.ps1
@@ -14,10 +14,18 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
+$PinnedCommit = "7d95ac02"  # Pin to tested commit (v4.3.5+)
+
 $RepoDir = "src"
 if (-not (Test-Path $RepoDir)) {
-    Write-Host "Cloning libzmq..." -ForegroundColor Gray
+    Write-Host "Cloning libzmq (pinned: $PinnedCommit)..." -ForegroundColor Gray
     git clone https://github.com/zeromq/libzmq $RepoDir
+    Push-Location $RepoDir
+    git checkout $PinnedCommit
+    Pop-Location
+} else {
+    Write-Host "libzmq source already exists at '$RepoDir'. Skipping clone." -ForegroundColor Yellow
+    Write-Host "  To rebuild from scratch, delete '$RepoDir/' and re-run." -ForegroundColor Yellow
 }
 
 Push-Location $RepoDir

--- a/third_party/libzmq/build.sh
+++ b/third_party/libzmq/build.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 INSTALL_DIR=${1:-"../install"}
 BUILD_TYPE=${2:-"Release"}
+PINNED_COMMIT="7d95ac02"  # Pin to tested commit (v4.3.5+)
 
 REPO_DIR="src"
 if [ ! -d "$REPO_DIR" ]; then
-    echo "Cloning libzmq..."
+    echo "Cloning libzmq (pinned: $PINNED_COMMIT)..."
     git clone https://github.com/zeromq/libzmq "$REPO_DIR"
+    cd "$REPO_DIR"
+    git checkout "$PINNED_COMMIT"
+    cd ..
+else
+    echo "libzmq source already exists at '$REPO_DIR'. Skipping clone."
+    echo "  To rebuild from scratch, delete '$REPO_DIR/' and re-run."
 fi
 
 cd "$REPO_DIR"
+
+echo "Initializing submodules..."
+git submodule update --init --recursive
+
 mkdir -p build
 cd build
 


### PR DESCRIPTION
Pin CoACD (c7436bf), MuJoCo (47264877), and libzmq (7d95ac02) to tested commits in build scripts. Fix CoACD_run call for new real_metric parameter. Closes #1