### PR TITLE
Replace silent Python auto-install with explicit dialog flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ docs/api/
 docs/_parsed_headers.json
 site/
 
+# Per-machine local settings (Python path, etc.)
+Config/LocalUnrealRoboticsLab.ini
+
 # Debug/log artifacts
 MUJOCO_LOG.TXT
 *.log

--- a/Scripts/clean_meshes.py
+++ b/Scripts/clean_meshes.py
@@ -190,10 +190,12 @@ def process_xml(xml_path: Path):
                     output_plan.append((mesh_el, source_path, source_path, output_glb))
                 else:
                     # Rename: link1.stl -> link1_1.stl, link1_1.glb
+                    # Save to meshdir root (not the source subdirectory) so the
+                    # XML file attribute stays a simple filename relative to meshdir.
                     new_stem = f"{glb_stem}_{i}"
                     ext = source_path.suffix  # .stl, .obj, etc.
-                    renamed_source = source_path.parent / f"{new_stem}{ext}"
-                    output_glb = source_path.parent / f"{new_stem}.glb"
+                    renamed_source = mesh_base / f"{new_stem}{ext}"
+                    output_glb = mesh_base / f"{new_stem}.glb"
 
                     # Update XML file attribute (relative to meshdir)
                     new_file_attr = f"{new_stem}{ext}"
@@ -203,6 +205,9 @@ def process_xml(xml_path: Path):
                     print(f"    -> Renaming '{mesh_name}': {source_path.name} -> {new_stem}{ext}")
 
                     # Copy the source file to the new name
+                    if not source_path.exists():
+                        print(f"    x Source file missing: {source_path} — skipping")
+                        continue
                     if not renamed_source.exists() or renamed_source.stat().st_mtime < source_path.stat().st_mtime:
                         shutil.copy2(str(source_path), str(renamed_source))
                         print(f"    -> Copied {source_path.name} -> {renamed_source.name}")

--- a/Source/URLabEditor/Private/MjPythonHelper.cpp
+++ b/Source/URLabEditor/Private/MjPythonHelper.cpp
@@ -178,6 +178,9 @@ bool FMjPythonHelper::InstallPythonPackages(const FString& PythonPath, FString& 
 
 FString FMjPythonHelper::EnsurePythonReady()
 {
+    // If no INI exists, always show the dialog so the user explicitly chooses
+    bool bNeedsFirstTimeSetup = GetStoredPythonOverride().IsEmpty();
+
     FString PythonPath = ResolvePythonPath();
     bool bIsUEBundled = (PythonPath == GetUEBundledPythonPath());
 
@@ -239,27 +242,50 @@ FString FMjPythonHelper::EnsurePythonReady()
     }
 
     // Check for required packages
-    if (!CheckPythonPackages(PythonPath))
+    // Show package dialog if packages are missing OR if this is first-time setup
+    // (no INI exists). First-time setup always shows the dialog so the user
+    // explicitly confirms which Python to use.
+    if (!CheckPythonPackages(PythonPath) || bNeedsFirstTimeSetup)
     {
         FString EnvLabel = bIsUEBundled
             ? TEXT("Unreal Engine's bundled Python")
             : FString::Printf(TEXT("your selected Python at:\n%s"), *PythonPath);
 
-        FText Title = FText::FromString(TEXT("Python Packages Required"));
-        FText Message = FText::FromString(FString::Printf(
-            TEXT("URLab needs the 'trimesh', 'numpy', and 'scipy' Python packages to preprocess mesh files.\n\n")
-            TEXT("Unreal Engine does not natively support all mesh formats used by MuJoCo, ")
-            TEXT("so these packages are used to convert and prepare meshes for import.\n\n")
-            TEXT("These will be installed to %s.\n\n")
-            TEXT("Install now?\n\n")
-            TEXT("Note: The editor will be unresponsive during installation. ")
-            TEXT("This may take a minute.\n\n")
-            TEXT("Alternatively, you can install these manually in your preferred Python environment:\n")
-            TEXT("  <your-python> -m pip install trimesh numpy scipy\n")
-            TEXT("Then set the path in Config/LocalUnrealRoboticsLab.ini in the plugin directory.\n\n")
-            TEXT("Click 'Yes' to install, 'No' to skip mesh preprocessing, ")
-            TEXT("or 'Cancel' to choose a different Python interpreter."),
-            *EnvLabel));
+        bool bPackagesPresent = CheckPythonPackages(PythonPath);
+
+        FText Title = FText::FromString(bPackagesPresent
+            ? TEXT("Python Setup")
+            : TEXT("Python Packages Required"));
+
+        FString MessageStr;
+        if (bPackagesPresent)
+        {
+            // First-time setup — packages already installed, just confirming Python choice
+            MessageStr = FString::Printf(
+                TEXT("URLab uses Python to preprocess mesh files during MJCF import.\n\n")
+                TEXT("Required packages are already installed in %s.\n\n")
+                TEXT("Click 'Yes' to use this Python, 'No' to skip mesh preprocessing, ")
+                TEXT("or 'Cancel' to choose a different Python interpreter."),
+                *EnvLabel);
+        }
+        else
+        {
+            MessageStr = FString::Printf(
+                TEXT("URLab needs the 'trimesh', 'numpy', and 'scipy' Python packages to preprocess mesh files.\n\n")
+                TEXT("Unreal Engine does not natively support all mesh formats used by MuJoCo, ")
+                TEXT("so these packages are used to convert and prepare meshes for import.\n\n")
+                TEXT("These will be installed to %s.\n\n")
+                TEXT("Install now?\n\n")
+                TEXT("Note: The editor will be unresponsive during installation. ")
+                TEXT("This may take a minute.\n\n")
+                TEXT("Alternatively, you can install these manually in your preferred Python environment:\n")
+                TEXT("  <your-python> -m pip install trimesh numpy scipy\n")
+                TEXT("Then set the path in Config/LocalUnrealRoboticsLab.ini in the plugin directory.\n\n")
+                TEXT("Click 'Yes' to install, 'No' to skip mesh preprocessing, ")
+                TEXT("or 'Cancel' to choose a different Python interpreter."),
+                *EnvLabel);
+        }
+        FText Message = FText::FromString(MessageStr);
 
         EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNoCancel, Message, Title);
 
@@ -317,27 +343,30 @@ FString FMjPythonHelper::EnsurePythonReady()
             }
         }
 
-        // Install packages
-        FString InstallLog;
-        if (!InstallPythonPackages(PythonPath, InstallLog))
+        // Install packages if not already present
+        if (!bPackagesPresent)
         {
-            FMessageDialog::Open(EAppMsgType::Ok,
-                FText::FromString(FString::Printf(
-                    TEXT("Failed to install packages. You can install them manually by running:\n\n")
-                    TEXT("%s -m pip install trimesh numpy\n\n")
-                    TEXT("Error log:\n%s"),
-                    *PythonPath, *InstallLog)),
-                FText::FromString(TEXT("Package Install Failed")));
-            return FString();
-        }
+            FString InstallLog;
+            if (!InstallPythonPackages(PythonPath, InstallLog))
+            {
+                FMessageDialog::Open(EAppMsgType::Ok,
+                    FText::FromString(FString::Printf(
+                        TEXT("Failed to install packages. You can install them manually by running:\n\n")
+                        TEXT("%s -m pip install trimesh numpy scipy\n\n")
+                        TEXT("Error log:\n%s"),
+                        *PythonPath, *InstallLog)),
+                    FText::FromString(TEXT("Package Install Failed")));
+                return FString();
+            }
 
-        // Verify install worked
-        if (!CheckPythonPackages(PythonPath))
-        {
-            FMessageDialog::Open(EAppMsgType::Ok,
-                FText::FromString(TEXT("Packages were installed but still cannot be imported. Check your Python environment.")),
-                FText::FromString(TEXT("Package Verification Failed")));
-            return FString();
+            // Verify install worked
+            if (!CheckPythonPackages(PythonPath))
+            {
+                FMessageDialog::Open(EAppMsgType::Ok,
+                    FText::FromString(TEXT("Packages were installed but still cannot be imported. Check your Python environment.")),
+                    FText::FromString(TEXT("Package Verification Failed")));
+                return FString();
+            }
         }
     }
 

--- a/Source/URLabEditor/Private/MjPythonHelper.cpp
+++ b/Source/URLabEditor/Private/MjPythonHelper.cpp
@@ -1,0 +1,346 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "MjPythonHelper.h"
+#include "URLabEditorLogging.h"
+#include "Misc/ConfigCacheIni.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
+#include "Interfaces/IPluginManager.h"
+#include "Misc/MessageDialog.h"
+#include "Misc/ScopedSlowTask.h"
+#include "DesktopPlatformModule.h"
+#include "Framework/Application/SlateApplication.h"
+
+FString FMjPythonHelper::GetLocalIniPath()
+{
+    TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin("UnrealRoboticsLab");
+    if (!Plugin.IsValid())
+    {
+        UE_LOG(LogURLabEditor, Warning, TEXT("[Python] Could not find UnrealRoboticsLab plugin. Using project config dir."));
+        return FPaths::ConvertRelativePathToFull(FPaths::ProjectPluginsDir() / TEXT("UnrealRoboticsLab") / TEXT("Config") / TEXT("LocalUnrealRoboticsLab.ini"));
+    }
+    FString FullPath = FPaths::ConvertRelativePathToFull(Plugin->GetBaseDir() / TEXT("Config") / TEXT("LocalUnrealRoboticsLab.ini"));
+    UE_LOG(LogURLabEditor, Verbose, TEXT("[Python] Local INI path: %s"), *FullPath);
+    return FullPath;
+}
+
+FString FMjPythonHelper::GetUEBundledPythonPath()
+{
+    FString PythonDir = FPaths::EngineDir() / TEXT("Binaries/ThirdParty/Python3");
+#if PLATFORM_WINDOWS
+    FString Path = PythonDir / TEXT("Win64/python.exe");
+#elif PLATFORM_LINUX
+    FString Path = PythonDir / TEXT("Linux/bin/python3");
+#elif PLATFORM_MAC
+    FString Path = PythonDir / TEXT("Mac/bin/python3");
+#else
+    FString Path;
+#endif
+    return FPaths::ConvertRelativePathToFull(Path);
+}
+
+FString FMjPythonHelper::GetStoredPythonOverride()
+{
+    FString IniPath = GetLocalIniPath();
+    if (!FPaths::FileExists(IniPath)) return FString();
+
+    FString FileContent;
+    if (!FFileHelper::LoadFileToString(FileContent, *IniPath)) return FString();
+
+    // Parse simple INI: look for PythonPath= line
+    TArray<FString> Lines;
+    FileContent.ParseIntoArrayLines(Lines);
+    for (const FString& Line : Lines)
+    {
+        FString Trimmed = Line.TrimStartAndEnd();
+        if (Trimmed.StartsWith(TEXT("PythonPath=")))
+        {
+            return Trimmed.Mid(11).TrimStartAndEnd();
+        }
+    }
+    return FString();
+}
+
+void FMjPythonHelper::StorePythonOverride(const FString& PythonPath)
+{
+    FString IniPath = GetLocalIniPath();
+    FString AbsPythonPath = FPaths::ConvertRelativePathToFull(PythonPath);
+
+    // Write directly to file — GConfig can silently fail for paths outside the project
+    FString IniContent = FString::Printf(TEXT("[PythonSettings]\nPythonPath=%s\n"), *AbsPythonPath);
+    if (FFileHelper::SaveStringToFile(IniContent, *IniPath))
+    {
+        UE_LOG(LogURLabEditor, Log, TEXT("[Python] Stored Python path '%s' to config: %s"), *AbsPythonPath, *IniPath);
+    }
+    else
+    {
+        UE_LOG(LogURLabEditor, Warning, TEXT("[Python] Failed to write config file: %s"), *IniPath);
+    }
+}
+
+FString FMjPythonHelper::ResolvePythonPath()
+{
+    // 1. Check user override
+    FString Override = GetStoredPythonOverride();
+    if (!Override.IsEmpty() && FPaths::FileExists(Override))
+    {
+        return Override;
+    }
+
+    // 2. Fall back to UE's bundled Python
+    FString Bundled = GetUEBundledPythonPath();
+    if (FPaths::FileExists(Bundled))
+    {
+        return Bundled;
+    }
+
+    // 3. Try system PATH as last resort
+    return TEXT("python");
+}
+
+bool FMjPythonHelper::ValidatePythonBinary(const FString& PythonPath)
+{
+    int32 ReturnCode = -1;
+    FString StdOut, StdErr;
+    FPlatformProcess::ExecProcess(*PythonPath, TEXT("--version"), &ReturnCode, &StdOut, &StdErr);
+    if (ReturnCode == 0)
+    {
+        FString Version = StdOut.IsEmpty() ? StdErr : StdOut; // Python 2 prints to stderr
+        UE_LOG(LogURLabEditor, Log, TEXT("[Python] Validated: %s -> %s"), *PythonPath, *Version.TrimStartAndEnd());
+        return true;
+    }
+    return false;
+}
+
+bool FMjPythonHelper::CheckPythonPackages(const FString& PythonPath)
+{
+    int32 ReturnCode = -1;
+    FString StdOut, StdErr;
+    FPlatformProcess::ExecProcess(*PythonPath, TEXT("-c \"import trimesh; import numpy; import scipy\""), &ReturnCode, &StdOut, &StdErr);
+    return (ReturnCode == 0);
+}
+
+bool FMjPythonHelper::InstallPythonPackages(const FString& PythonPath, FString& OutLog)
+{
+    // First check if pip is available
+    {
+        int32 PipCheck = -1;
+        FString PipOut, PipErr;
+        FPlatformProcess::ExecProcess(*PythonPath, TEXT("-m pip --version"), &PipCheck, &PipOut, &PipErr);
+        if (PipCheck != 0)
+        {
+            OutLog = FString::Printf(
+                TEXT("pip is not available in this Python environment.\n\n")
+                TEXT("Please install pip first, or choose a different Python interpreter.\n")
+                TEXT("You can also install packages manually:\n")
+                TEXT("  %s -m ensurepip\n")
+                TEXT("  %s -m pip install trimesh numpy scipy"),
+                *PythonPath, *PythonPath);
+            UE_LOG(LogURLabEditor, Warning, TEXT("[Python] pip not available: %s"), *PipErr);
+            return false;
+        }
+    }
+
+    int32 ReturnCode = -1;
+    FString StdOut, StdErr;
+    UE_LOG(LogURLabEditor, Log, TEXT("[Python] Installing packages: %s -m pip install trimesh numpy scipy"), *PythonPath);
+    FPlatformProcess::ExecProcess(*PythonPath, TEXT("-m pip install trimesh numpy scipy"), &ReturnCode, &StdOut, &StdErr);
+    OutLog = StdOut + TEXT("\n") + StdErr;
+    if (ReturnCode == 0)
+    {
+        UE_LOG(LogURLabEditor, Log, TEXT("[Python] Package install succeeded."));
+        return true;
+    }
+    UE_LOG(LogURLabEditor, Warning, TEXT("[Python] Package install failed (code %d): %s"), ReturnCode, *OutLog);
+    return false;
+}
+
+FString FMjPythonHelper::EnsurePythonReady()
+{
+    FString PythonPath = ResolvePythonPath();
+    bool bIsUEBundled = (PythonPath == GetUEBundledPythonPath());
+
+    // Validate the resolved Python
+    if (!ValidatePythonBinary(PythonPath))
+    {
+        // Python not found at all — prompt for path
+        FText Title = FText::FromString(TEXT("Python Interpreter Not Found"));
+        FText Message = FText::FromString(FString::Printf(
+            TEXT("URLab uses Python to preprocess mesh files during MJCF import.\n\n")
+            TEXT("This is needed because Unreal Engine does not natively support all mesh formats ")
+            TEXT("used by MuJoCo (e.g. STL, OBJ with certain features). The preprocessing step ")
+            TEXT("converts meshes to a compatible format and resolves asset conflicts.\n\n")
+            TEXT("Could not find a valid Python interpreter at:\n%s\n\n")
+            TEXT("Would you like to browse for your Python interpreter?\n\n")
+            TEXT("Click 'No' to skip mesh preprocessing (import will use raw XML — some meshes may not display correctly)."),
+            *PythonPath));
+
+        EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNo, Message, Title);
+        if (Result == EAppReturnType::No)
+        {
+            return FString(); // User chose to skip
+        }
+
+        // Open file picker
+        TArray<FString> OutFiles;
+        IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+        if (DesktopPlatform)
+        {
+            DesktopPlatform->OpenFileDialog(
+                FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+                TEXT("Select Python Interpreter"),
+                TEXT(""),
+                TEXT(""),
+#if PLATFORM_WINDOWS
+                TEXT("Python Executable (*.exe)|*.exe"),
+#else
+                TEXT("All Files (*)|*"),
+#endif
+                0, OutFiles);
+        }
+
+        if (OutFiles.Num() == 0)
+        {
+            return FString(); // Cancelled
+        }
+
+        PythonPath = OutFiles[0];
+        if (!ValidatePythonBinary(PythonPath))
+        {
+            FMessageDialog::Open(EAppMsgType::Ok,
+                FText::FromString(FString::Printf(TEXT("'%s' is not a valid Python interpreter."), *PythonPath)),
+                FText::FromString(TEXT("Invalid Python")));
+            return FString();
+        }
+
+        StorePythonOverride(PythonPath);
+        bIsUEBundled = false;
+    }
+
+    // Check for required packages
+    if (!CheckPythonPackages(PythonPath))
+    {
+        FString EnvLabel = bIsUEBundled
+            ? TEXT("Unreal Engine's bundled Python")
+            : FString::Printf(TEXT("your selected Python at:\n%s"), *PythonPath);
+
+        FText Title = FText::FromString(TEXT("Python Packages Required"));
+        FText Message = FText::FromString(FString::Printf(
+            TEXT("URLab needs the 'trimesh', 'numpy', and 'scipy' Python packages to preprocess mesh files.\n\n")
+            TEXT("Unreal Engine does not natively support all mesh formats used by MuJoCo, ")
+            TEXT("so these packages are used to convert and prepare meshes for import.\n\n")
+            TEXT("These will be installed to %s.\n\n")
+            TEXT("Install now?\n\n")
+            TEXT("Note: The editor will be unresponsive during installation. ")
+            TEXT("This may take a minute.\n\n")
+            TEXT("Click 'Yes' to install, 'No' to skip mesh preprocessing, ")
+            TEXT("or 'Cancel' to choose a different Python interpreter."),
+            *EnvLabel));
+
+        EAppReturnType::Type Result = FMessageDialog::Open(EAppMsgType::YesNoCancel, Message, Title);
+
+        if (Result == EAppReturnType::No)
+        {
+            return FString(); // Skip
+        }
+        else if (Result == EAppReturnType::Cancel)
+        {
+            // User wants a different Python — open file picker
+            TArray<FString> OutFiles;
+            IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+            if (DesktopPlatform)
+            {
+                DesktopPlatform->OpenFileDialog(
+                    FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr),
+                    TEXT("Select Python Interpreter"),
+                    TEXT(""),
+                    TEXT(""),
+#if PLATFORM_WINDOWS
+                    TEXT("Python Executable (*.exe)|*.exe"),
+#else
+                    TEXT("All Files (*)|*"),
+#endif
+                    0, OutFiles);
+            }
+
+            if (OutFiles.Num() == 0) return FString();
+
+            PythonPath = OutFiles[0];
+            if (!ValidatePythonBinary(PythonPath))
+            {
+                FMessageDialog::Open(EAppMsgType::Ok,
+                    FText::FromString(FString::Printf(TEXT("'%s' is not a valid Python interpreter."), *PythonPath)),
+                    FText::FromString(TEXT("Invalid Python")));
+                return FString();
+            }
+            StorePythonOverride(PythonPath);
+
+            // Re-check packages with new Python
+            if (CheckPythonPackages(PythonPath))
+            {
+                UE_LOG(LogURLabEditor, Log, TEXT("[Python] Packages already available in selected Python."));
+                return PythonPath;
+            }
+
+            // Ask to install for the new Python
+            FText InstallMsg = FText::FromString(FString::Printf(
+                TEXT("Install 'trimesh', 'numpy', and 'scipy' to:\n%s?\n\n")
+                TEXT("The editor will be unresponsive during installation.\n\n")
+                TEXT("Click 'No' to skip mesh preprocessing."), *PythonPath));
+            if (FMessageDialog::Open(EAppMsgType::YesNo, InstallMsg, Title) == EAppReturnType::No)
+            {
+                return FString();
+            }
+        }
+
+        // Install packages
+        FString InstallLog;
+        if (!InstallPythonPackages(PythonPath, InstallLog))
+        {
+            FMessageDialog::Open(EAppMsgType::Ok,
+                FText::FromString(FString::Printf(
+                    TEXT("Failed to install packages. You can install them manually by running:\n\n")
+                    TEXT("%s -m pip install trimesh numpy\n\n")
+                    TEXT("Error log:\n%s"),
+                    *PythonPath, *InstallLog)),
+                FText::FromString(TEXT("Package Install Failed")));
+            return FString();
+        }
+
+        // Verify install worked
+        if (!CheckPythonPackages(PythonPath))
+        {
+            FMessageDialog::Open(EAppMsgType::Ok,
+                FText::FromString(TEXT("Packages were installed but still cannot be imported. Check your Python environment.")),
+                FText::FromString(TEXT("Package Verification Failed")));
+            return FString();
+        }
+    }
+
+    // Always save the resolved path so the user can see which Python is in use
+    StorePythonOverride(PythonPath);
+
+    UE_LOG(LogURLabEditor, Log, TEXT("[Python] Ready: %s"), *PythonPath);
+    return PythonPath;
+}

--- a/Source/URLabEditor/Private/MjPythonHelper.cpp
+++ b/Source/URLabEditor/Private/MjPythonHelper.cpp
@@ -254,6 +254,9 @@ FString FMjPythonHelper::EnsurePythonReady()
             TEXT("Install now?\n\n")
             TEXT("Note: The editor will be unresponsive during installation. ")
             TEXT("This may take a minute.\n\n")
+            TEXT("Alternatively, you can install these manually in your preferred Python environment:\n")
+            TEXT("  <your-python> -m pip install trimesh numpy scipy\n")
+            TEXT("Then set the path in Config/LocalUnrealRoboticsLab.ini in the plugin directory.\n\n")
             TEXT("Click 'Yes' to install, 'No' to skip mesh preprocessing, ")
             TEXT("or 'Cancel' to choose a different Python interpreter."),
             *EnvLabel));

--- a/Source/URLabEditor/Private/MujocoImportFactory.cpp
+++ b/Source/URLabEditor/Private/MujocoImportFactory.cpp
@@ -23,6 +23,7 @@
 
 #include "MujocoImportFactory.h"
 #include "MujocoGenerationAction.h"
+#include "MjPythonHelper.h"
 #include "MuJoCo/Core/MjArticulation.h"
 #include "Kismet2/KismetEditorUtilities.h"
 #include "Engine/Blueprint.h"
@@ -80,32 +81,19 @@ UObject* UMujocoImportFactory::FactoryCreateFile(UClass* InClass, UObject* InPar
 
             if (FPaths::FileExists(ScriptPath))
             {
-                // Check if Python is available
-                FString PythonExe = TEXT("python");
-                int32 ReturnCode = -1;
-                FString StdOut, StdErr;
+                FString PythonExe = FMjPythonHelper::EnsurePythonReady();
 
-                FPlatformProcess::ExecProcess(*PythonExe, TEXT("--version"), &ReturnCode, &StdOut, &StdErr);
-
-                if (ReturnCode == 0)
+                if (!PythonExe.IsEmpty())
                 {
-                    // Check if trimesh is installed
-                    FPlatformProcess::ExecProcess(*PythonExe, TEXT("-c \"import trimesh\""), &ReturnCode, &StdOut, &StdErr);
-
-                    if (ReturnCode != 0)
-                    {
-                        UE_LOG(LogURLabEditor, Log, TEXT("Installing trimesh dependency..."));
-                        FPlatformProcess::ExecProcess(*PythonExe, TEXT("-m pip install trimesh numpy"), &ReturnCode, &StdOut, &StdErr);
-                    }
-
                     // Run the clean script
+                    int32 ReturnCode = -1;
+                    FString StdOut, StdErr;
                     FString Args = FString::Printf(TEXT("\"%s\" \"%s\""), *ScriptPath, *Filename);
-                    UE_LOG(LogURLabEditor, Log, TEXT("Running mesh preparation: python %s"), *Args);
+                    UE_LOG(LogURLabEditor, Log, TEXT("Running mesh preparation: %s %s"), *PythonExe, *Args);
                     FPlatformProcess::ExecProcess(*PythonExe, *Args, &ReturnCode, &StdOut, &StdErr);
 
                     if (ReturnCode == 0)
                     {
-                        // Check if _ue.xml was created
                         FString UeXmlPath = FPaths::Combine(
                             FPaths::GetPath(Filename),
                             FPaths::GetBaseFilename(Filename) + TEXT("_ue.xml"));
@@ -124,7 +112,7 @@ UObject* UMujocoImportFactory::FactoryCreateFile(UClass* InClass, UObject* InPar
                 }
                 else
                 {
-                    UE_LOG(LogURLabEditor, Log, TEXT("Python not found — skipping mesh preparation."));
+                    UE_LOG(LogURLabEditor, Log, TEXT("Python not configured — skipping mesh preparation."));
                 }
             }
         }

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -410,17 +410,6 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
                       UE_LOG(LogURLabEditor, Log, TEXT("[Mesh Import]   -> Resolved mesh '%s' to file: %s"), *MeshName, *MeshFile);
                       FString MeshImportPath = AssetImportPath + TEXT("/Meshes");
                       UStaticMesh* NewMesh = ImportSingleMesh(MeshFile, MeshImportPath);
-
-                      // Fallback to FBX if raw failed
-                      if (!NewMesh)
-                      {
-                          FString FbxSource = FPaths::ChangeExtension(MeshFile, TEXT("fbx"));
-                          if (FbxSource != MeshFile)
-                          {
-                              UE_LOG(LogURLabEditor, Warning, TEXT("Failed to import raw mesh %s, trying fallback: %s"), *MeshFile, *FbxSource);
-                              NewMesh = ImportSingleMesh(FbxSource, MeshImportPath);
-                          }
-                      }
                       if (NewMesh)
                       {
                             FString VizNodeName = FString::Printf(TEXT("Viz_%s"), *MeshName);
@@ -853,17 +842,6 @@ void UMujocoGenerationAction::ParseAssetsRecursive(const FXmlNode* Node, const F
             }
 
             FString FullPath = FPaths::Combine(EffectiveMeshBase, MeshFile);
-
-            // Fallback check
-            if (!FPaths::FileExists(FullPath))
-            {
-                 FString FbxPath = FPaths::ChangeExtension(FullPath, TEXT("fbx"));
-                 if (FPaths::FileExists(FbxPath))
-                 {
-                     UE_LOG(LogURLabEditor, Warning, TEXT("Mesh %s not found at %s, using fallback %s"), *MeshName, *FullPath, *FbxPath);
-                     FullPath = FbxPath;
-                 }
-            }
 
             if (!OutMeshAssets.Contains(MeshName))
             {

--- a/Source/URLabEditor/Public/MjPythonHelper.h
+++ b/Source/URLabEditor/Public/MjPythonHelper.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * @class FMjPythonHelper
+ * @brief Manages Python interpreter resolution, package checking, and install prompts.
+ *
+ * Default: uses UE's bundled Python (Engine/Binaries/ThirdParty/Python3/).
+ * Override: user can specify a custom path stored in Config/LocalUnrealRoboticsLab.ini.
+ */
+class FMjPythonHelper
+{
+public:
+	/**
+	 * @brief Resolve the Python interpreter to use.
+	 * Checks LocalUnrealRoboticsLab.ini for a user override, otherwise returns UE's bundled Python.
+	 * @return Path to the python executable, or empty string if none found.
+	 */
+	static FString ResolvePythonPath();
+
+	/** @brief Get UE's bundled Python path. */
+	static FString GetUEBundledPythonPath();
+
+	/** @brief Read user's custom Python override from local config. */
+	static FString GetStoredPythonOverride();
+
+	/** @brief Store a custom Python path to local config. */
+	static void StorePythonOverride(const FString& PythonPath);
+
+	/** @brief Validate a Python binary by running --version. */
+	static bool ValidatePythonBinary(const FString& PythonPath);
+
+	/** @brief Check if trimesh and numpy are importable. */
+	static bool CheckPythonPackages(const FString& PythonPath);
+
+	/** @brief Run pip install trimesh numpy. Returns true on success. */
+	static bool InstallPythonPackages(const FString& PythonPath, FString& OutLog);
+
+	/**
+	 * @brief Ensure Python is available with required packages.
+	 * Shows dialogs as needed. Returns the resolved Python path, or empty if user skipped.
+	 */
+	static FString EnsurePythonReady();
+
+private:
+	static FString GetLocalIniPath();
+};

--- a/Source/URLabEditor/URLabEditor.Build.cs
+++ b/Source/URLabEditor/URLabEditor.Build.cs
@@ -29,7 +29,8 @@ public class URLabEditor : ModuleRules
 		PrivateDependencyModuleNames.AddRange(new string[]
 		{
 			"InputCore",
-			"RenderCore"
+			"RenderCore",
+			"DesktopPlatform"
 		});
 	}
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -40,7 +40,7 @@ This is **not required** if you only use the plugin through the editor, Blueprin
 ### From MJCF XML
 
 1. Get a robot XML (e.g., from [MuJoCo Menagerie](https://github.com/google-deepmind/mujoco_menagerie)).
-2. Drag the XML into the Unreal Content Browser. The importer auto-runs `Scripts/clean_meshes.py` to convert meshes to GLB (falls back gracefully if Python is missing).
+2. Drag the XML into the Unreal Content Browser. On first import, the editor will prompt to install the required Python packages (`trimesh`, `numpy`, `scipy`) — by default these are installed to UE's bundled Python, so no external setup is needed. You can also choose your own Python interpreter if preferred.
 3. A Blueprint is auto-generated with all joints, bodies, actuators, and sensors as components.
 
 ### Quick Convert (Static Meshes)

--- a/docs/guides/mujoco_import.md
+++ b/docs/guides/mujoco_import.md
@@ -100,6 +100,14 @@ python Scripts/clean_meshes.py path/to/robot.xml
 
 This produces a `_ue.xml` file with updated mesh references that you can drag into Unreal instead of the original XML.
 
+**Manual package install:** If you prefer to install packages yourself rather than using the dialog, run the following with your preferred Python interpreter:
+
+```bash
+/path/to/your/python -m pip install trimesh numpy scipy
+```
+
+Then make sure the same Python path is set in `Config/LocalUnrealRoboticsLab.ini` (see below). The plugin will detect the packages on next import and skip the install prompt.
+
 **Changing the Python interpreter:** The plugin stores your Python path in `Config/LocalUnrealRoboticsLab.ini` inside the plugin directory. This file is gitignored (per-machine). To switch interpreters, either delete the file (the dialog will re-appear on next import) or edit it directly:
 
 ```ini

--- a/docs/guides/mujoco_import.md
+++ b/docs/guides/mujoco_import.md
@@ -7,12 +7,13 @@ Unreal Robotics Lab can import standard MuJoCo XML (MJCF) files and reconstruct 
 ## Importing
 
 1. Drag your `.xml` file into the Unreal **Content Browser**.
-2. `UMujocoImportFactory` automatically runs `Scripts/clean_meshes.py` as a subprocess:
+2. On first import, the editor prompts to install required Python packages (`trimesh`, `numpy`, `scipy`). By default these install to UE's bundled Python — no external Python setup needed. You can also choose a custom interpreter (conda, venv, etc.) via the dialog. The chosen path is saved to `Config/LocalUnrealRoboticsLab.ini` (per-machine, not checked into source control).
+3. `UMujocoImportFactory` runs `Scripts/clean_meshes.py` using the configured Python:
    - Parses the XML to find all referenced mesh assets
    - Detects GLB stem conflicts (e.g., `link1.obj` and `link1.stl` both producing `link1.glb`) and renames them
    - Converts meshes to GLB (preserving UVs, stripping embedded textures)
    - Produces a `_ue.xml` with updated mesh references
-   - Graceful fallback: if Python or trimesh is missing, the raw XML is used instead
+   - If the user skips Python setup, the raw XML is used instead (some meshes may not display correctly)
 3. The factory creates an `AMjArticulation` Blueprint via four parsing passes:
    - **Pass 1:** Assets (meshes with scales, textures with file paths, materials with RGBA/texture refs)
    - **Pass 2:** Defaults (class hierarchy as `UMjDefault` components)
@@ -89,15 +90,22 @@ The importer creates shared Unreal material instances keyed by XML `<material>` 
 
 The importer looks for mesh files relative to the XML file's directory. Found meshes are copied to a `/Meshes/` subfolder under the import target to avoid texture name collisions, then registered in MuJoCo's VFS during compilation.
 
-**Format priority:** FBX > GLB > OBJ. The importer tries multiple paths via `ImportSingleMesh()`: GLB (via Interchange), then raw OBJ/STL (via FBX factory), then FBX fallback. If all fail, the geom is created without a visual mesh but still exists as a collision primitive. A warning is logged and compilation still succeeds.
+**Format priority:** GLB > OBJ. The importer tries GLB first (via Interchange), then raw OBJ/STL. If all fail, the geom is created without a visual mesh but still exists as a collision primitive. A warning is logged and compilation still succeeds.
 
-**Auto mesh preparation:** The `clean_meshes_trimesh.py` script runs automatically during import (see [Importing](#importing) above). You can also run it manually:
+**Auto mesh preparation:** The `clean_meshes.py` script runs automatically during import (see [Importing](#importing) above). You can also run it manually:
 
 ```bash
 python Scripts/clean_meshes.py path/to/robot.xml
 ```
 
 This produces a `_ue.xml` file with updated mesh references that you can drag into Unreal instead of the original XML.
+
+**Changing the Python interpreter:** The plugin stores your Python path in `Config/LocalUnrealRoboticsLab.ini` inside the plugin directory. This file is gitignored (per-machine). To switch interpreters, either delete the file (the dialog will re-appear on next import) or edit it directly:
+
+```ini
+[PythonSettings]
+PythonPath=C:/Users/you/miniconda3/envs/myenv/python.exe
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the silent `pip install trimesh` auto-install (which failed due to permissions, conda/venv conflicts, and system Python contamination — see #9) with an explicit dialog-based flow.

- **Defaults to UE's bundled Python** — ships with every UE install, zero configuration needed
- **Explicit install dialog** — prompts when `trimesh`/`numpy`/`scipy` are missing with options: Install / Use Different Python / Skip
- **pip validation** — checks pip is available before attempting install, shows manual instructions if not
- **Persistent config** — chosen Python path saved to `Config/LocalUnrealRoboticsLab.ini` (gitignored, per-machine)
- **File picker** — users can browse for their conda/venv/system Python interpreter
- **No silent modifications** — nothing is installed without explicit user consent
- Removes FBX fallback from import pipeline (no longer needed)
- Fixes `clean_meshes.py` to skip missing source files and save conflict-renamed meshes to meshdir root

Closes [#9](https://github.com/URLab-Sim/UnrealRoboticsLab/pull/9): supersedes the documentation fix. Thanks to @huhai463127310 for identifying the issue and suggesting allowing user defined interpreter paths.
