### PR TITLE
Import mesh scale defined in <default> blocks

### DIFF
--- a/Source/URLabEditor/Private/MujocoGenerationAction.cpp
+++ b/Source/URLabEditor/Private/MujocoGenerationAction.cpp
@@ -129,6 +129,9 @@ void UMujocoGenerationAction::GenerateForBlueprintXml(UBlueprint* BP, const FStr
     FString AssetImportPath = BaseContentPath + BaseName + TEXT("_Assets");
     AssetImportPath = UPackageTools::SanitizePackageName(AssetImportPath);
 
+    // 0. Pre-scan: collect default mesh scales so asset parsing can inherit them
+    CollectDefaultMeshScales(Root);
+
     // 1. Pass: Resolved Assets
     TMap<FString, FString> MeshAssets;
     TMap<FString, FVector> MeshScales;

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -767,6 +767,48 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
     }
 }
 
+void UMujocoGenerationAction::CollectDefaultMeshScales(const FXmlNode* Node, const FString& CurrentClass)
+{
+    if (!Node) return;
+    const FString Tag = Node->GetTag();
+
+    if (Tag.Equals(TEXT("default")))
+    {
+        FString ClassName = Node->GetAttribute(TEXT("class"));
+        if (ClassName.IsEmpty()) ClassName = TEXT("main");
+
+        for (const FXmlNode* Child : Node->GetChildrenNodes())
+        {
+            if (Child->GetTag().Equals(TEXT("mesh")))
+            {
+                FString ScaleStr = Child->GetAttribute(TEXT("scale"));
+                if (!ScaleStr.IsEmpty())
+                {
+                    TArray<FString> Parts;
+                    ScaleStr.ParseIntoArray(Parts, TEXT(" "), true);
+                    if (Parts.Num() >= 3)
+                    {
+                        FVector Scale(FCString::Atof(*Parts[0]), FCString::Atof(*Parts[1]), FCString::Atof(*Parts[2]));
+                        DefaultMeshScales.Add(ClassName, Scale);
+                        UE_LOG(LogURLabEditor, Log, TEXT("[Default Mesh Scale] class='%s' scale=%s"), *ClassName, *Scale.ToString());
+                    }
+                }
+            }
+            else if (Child->GetTag().Equals(TEXT("default")))
+            {
+                CollectDefaultMeshScales(Child, ClassName);
+            }
+        }
+    }
+    else
+    {
+        for (const FXmlNode* Child : Node->GetChildrenNodes())
+        {
+            CollectDefaultMeshScales(Child, CurrentClass);
+        }
+    }
+}
+
 void UMujocoGenerationAction::ParseAssetsRecursive(const FXmlNode* Node, const FString& XMLDir, TMap<FString, FString>& OutMeshAssets, TMap<FString, FVector>& OutMeshScales, TMap<FString, FString>& OutTextureAssets, TMap<FString, FMuJoCoMaterialData>& OutMaterialData, const FString& MeshDir, const FString& TextureDir, const FString& AssetDir)
 {
     if (!Node) return;
@@ -848,7 +890,7 @@ void UMujocoGenerationAction::ParseAssetsRecursive(const FXmlNode* Node, const F
                 UE_LOG(LogURLabEditor, Log, TEXT("[Mesh Map] Adding mesh: name='%s' -> file='%s'"), *MeshName, *FullPath);
                 OutMeshAssets.Add(MeshName, FullPath);
 
-                // Scale parsing
+                // Scale: explicit attribute > default class > main default > (1,1,1)
                 FVector Scale(1.0f);
                 FString ScaleStr = Node->GetAttribute(TEXT("scale"));
                 if (!ScaleStr.IsEmpty())
@@ -860,6 +902,16 @@ void UMujocoGenerationAction::ParseAssetsRecursive(const FXmlNode* Node, const F
                         Scale.X = FCString::Atof(*Parts[0]);
                         Scale.Y = FCString::Atof(*Parts[1]);
                         Scale.Z = FCString::Atof(*Parts[2]);
+                    }
+                }
+                else
+                {
+                    // Fall back to default mesh scale
+                    FString MeshClass = Node->GetAttribute(TEXT("class"));
+                    if (MeshClass.IsEmpty()) MeshClass = TEXT("main");
+                    if (DefaultMeshScales.Contains(MeshClass))
+                    {
+                        Scale = DefaultMeshScales[MeshClass];
                     }
                 }
                 OutMeshScales.Add(MeshName, Scale);

--- a/Source/URLabEditor/Public/MujocoGenerationAction.h
+++ b/Source/URLabEditor/Public/MujocoGenerationAction.h
@@ -189,6 +189,10 @@ public:
      */
 private:
     TMap<FString, USCS_Node*> CreatedDefaultNodes;
+    TMap<FString, FVector> DefaultMeshScales;
+
+    /** Pre-scans the XML for <default><mesh scale="..."/> to populate DefaultMeshScales. */
+    void CollectDefaultMeshScales(const class FXmlNode* Node, const FString& CurrentClass = TEXT("main"));
 	UStaticMesh* ImportSingleMesh(const FString& SourcePath, const FString& DestinationPath);
 
     UTexture2D* ImportSingleTexture(const FString& SourcePath, const FString& DestinationPath);


### PR DESCRIPTION
## Summary

- Some MJCF files (e.g. Robotis OP3) set mesh scale inside a `<default>` block rather than on each `<mesh>` element. The importer previously ignored those and loaded meshes at `(1, 1, 1)` scale.
- Adds a pre-scan pass that collects `<default><mesh scale="..."/>` entries keyed by class name (including nested defaults), and uses them as a fallback when an `<asset><mesh>` has no explicit `scale` attribute.

Resolution order: explicit `scale` attribute → class-specific default → `main` default → `(1,1,1)`.