### PR TITLE
Physics viz: MuJoCo-style body overlay shaders (Island + Segmentation)

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
@@ -48,6 +48,10 @@ FString UMjQuickConvertComponent::GetBodyName() {
     return m_BodyName;
 }
 
+int32 UMjQuickConvertComponent::GetMjBodyId() const {
+    return m_CreatedBody ? m_CreatedBody->GetMj().id : -1;
+}
+
 void UMjQuickConvertComponent::BeginPlay() {
     Super::BeginPlay();
 }

--- a/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
@@ -155,9 +155,16 @@ void AAMjManager::BeginPlay() {
 
     if (PhysicsEngine)
     {
-        // Register debug data capture as a post-step callback
+        // Register debug data capture as a post-step callback. Fires whenever any
+        // debug overlay needs fresh mjData — contact forces (key 1), body shader
+        // overlays (Island / Segmentation modes), or tendon/muscle rendering.
         PhysicsEngine->RegisterPostStepCallback([this](mjModel* m, mjData* d) {
-            if (DebugVisualizer && DebugVisualizer->bShowDebug)
+            if (!DebugVisualizer) return;
+            const bool bNeedsCapture =
+                DebugVisualizer->bShowDebug ||
+                DebugVisualizer->DebugShaderMode != EMjDebugShaderMode::Off ||
+                DebugVisualizer->bGlobalDrawTendons;
+            if (bNeedsCapture)
             {
                 DebugVisualizer->CaptureDebugData();
             }

--- a/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
@@ -24,9 +24,13 @@
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Core/MjPhysicsEngine.h"
 #include "MuJoCo/Utils/MjUtils.h"
+#include "MuJoCo/Utils/MjColor.h"
 #include "MuJoCo/Core/MjArticulation.h"
+#include "MuJoCo/Components/Geometry/MjGeom.h"
 #include "MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h"
 #include "DrawDebugHelpers.h"
+#include "Materials/MaterialInterface.h"
+#include "Materials/MaterialInstanceDynamic.h"
 #include "Utils/URLabLogging.h"
 
 UMjDebugVisualizer::UMjDebugVisualizer()
@@ -34,9 +38,17 @@ UMjDebugVisualizer::UMjDebugVisualizer()
     PrimaryComponentTick.bCanEverTick = true;
 }
 
+void UMjDebugVisualizer::BeginPlay()
+{
+    Super::BeginPlay();
+    InitializeOverlayMaterial();
+}
+
 void UMjDebugVisualizer::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
     Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    UpdateBodyOverlays();
 
     if (!bShowDebug) return;
 
@@ -98,6 +110,61 @@ void UMjDebugVisualizer::CaptureDebugData()
         mjtNum cforce[6];
         mj_contactForce(Model, Data, i, cforce);
         DebugData.ContactForces.Add((float)cforce[0]);
+    }
+
+    DebugData.BodyAwake.SetNumUninitialized(Model->nbody);
+    for (int32 i = 0; i < Model->nbody; ++i)
+    {
+        DebugData.BodyAwake[i] = Data->body_awake ? Data->body_awake[i] : 1;
+    }
+
+    // Per-body Halton seed, matching MuJoCo's native islandColor algorithm in
+    // engine_vis_visualize.c: use the active constraint island's dof-address if
+    // available, otherwise fall back to the kinematic tree's dof-address so
+    // sleeping bodies keep a stable colour. When asleep, mj_sleepCycle collapses
+    // connected sleep-cycle trees to their smallest index so a group of bodies
+    // resting on each other share one colour.
+    DebugData.BodyIslandSeed.Init(-1, Model->nbody);
+    const bool bSleepEnabled = (Model->opt.enableflags & mjENBL_SLEEP) != 0;
+    for (int32 b = 0; b < Model->nbody; ++b)
+    {
+        const int32 WeldId = Model->body_weldid ? Model->body_weldid[b] : b;
+        if (WeldId < 0 || WeldId >= Model->nbody) continue;
+        if (!Model->body_dofnum || Model->body_dofnum[WeldId] == 0) continue;
+
+        const int32 Dof = Model->body_dofadr ? Model->body_dofadr[WeldId] : -1;
+        if (Dof < 0 || Dof >= Model->nv) continue;
+
+        const int32 Island = (Data->nisland > 0 && Data->dof_island) ? Data->dof_island[Dof] : -1;
+        int32 H = (Island >= 0 && Data->island_dofadr) ? Data->island_dofadr[Island] : -1;
+
+        if (H == -1 && bSleepEnabled && Model->dof_treeid && Model->tree_dofadr)
+        {
+            int32 Tree = Model->dof_treeid[Dof];
+            const bool bBodyAwake = Data->body_awake ? (Data->body_awake[b] != 0) : true;
+            if (!bBodyAwake && Data->tree_asleep && Model->ntree > 0 &&
+                Tree >= 0 && Tree < Model->ntree)
+            {
+                // Reimplementation of MuJoCo's mj_sleepCycle (engine_sleep.c).
+                int32 Smallest = Tree;
+                int32 Current = Tree;
+                for (int32 Count = 0; Count <= Model->ntree; ++Count)
+                {
+                    const int32 Next = Data->tree_asleep[Current];
+                    if (Next < 0 || Next >= Model->ntree) { Smallest = -1; break; }
+                    if (Next < Smallest) Smallest = Next;
+                    Current = Next;
+                    if (Current == Tree) break;
+                }
+                Tree = Smallest;
+            }
+            if (Tree >= 0 && Tree < Model->ntree)
+            {
+                H = Model->tree_dofadr[Tree];
+            }
+        }
+
+        DebugData.BodyIslandSeed[b] = H;
     }
 }
 
@@ -201,4 +268,239 @@ void UMjDebugVisualizer::ToggleVisuals()
         }
     }
     UE_LOG(LogURLab, Log, TEXT("Visuals: %s"), bVisualsHidden ? TEXT("HIDDEN") : TEXT("VISIBLE"));
+}
+
+void UMjDebugVisualizer::CycleDebugShaderMode()
+{
+    const uint8 Count = static_cast<uint8>(EMjDebugShaderMode::SemanticSegmentation) + 1;
+    DebugShaderMode = static_cast<EMjDebugShaderMode>((static_cast<uint8>(DebugShaderMode) + 1) % Count);
+
+    const TCHAR* Label = TEXT("Off");
+    switch (DebugShaderMode)
+    {
+        case EMjDebugShaderMode::Island:                Label = TEXT("Island"); break;
+        case EMjDebugShaderMode::InstanceSegmentation:  Label = TEXT("Instance Segmentation"); break;
+        case EMjDebugShaderMode::SemanticSegmentation:  Label = TEXT("Semantic Segmentation"); break;
+        default: break;
+    }
+    UE_LOG(LogURLab, Log, TEXT("Debug shader mode: %s"), Label);
+}
+
+void UMjDebugVisualizer::ToggleTendons()
+{
+    bGlobalDrawTendons = !bGlobalDrawTendons;
+    UE_LOG(LogURLab, Log, TEXT("Tendon rendering: %s"), bGlobalDrawTendons ? TEXT("ON") : TEXT("OFF"));
+}
+
+void UMjDebugVisualizer::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    ClearBodyOverlays();
+    Super::EndPlay(EndPlayReason);
+}
+
+void UMjDebugVisualizer::ClearBodyOverlays()
+{
+    for (auto& Pair : OriginalMaterials)
+    {
+        UStaticMeshComponent* Mesh = Pair.Key.Get();
+        if (!Mesh) continue;
+        Mesh->SetMaterial(0, Pair.Value);
+
+        if (const TMap<int32, UMaterialInterface*>* Extra = OriginalSlotMaterials.Find(Pair.Key))
+        {
+            for (const auto& SlotPair : *Extra)
+            {
+                Mesh->SetMaterial(SlotPair.Key, SlotPair.Value);
+            }
+        }
+    }
+    OriginalMaterials.Reset();
+    OriginalSlotMaterials.Reset();
+    ActiveMIDs.Reset();
+}
+
+void UMjDebugVisualizer::UpdateBodyOverlays()
+{
+    if (DebugShaderMode == EMjDebugShaderMode::Off)
+    {
+        if (OriginalMaterials.Num() > 0) ClearBodyOverlays();
+        return;
+    }
+
+    if (!OverlayParentMaterial || OverlayColorParam.IsNone()) return;
+
+    AAMjManager* Manager = Cast<AAMjManager>(GetOwner());
+    if (!Manager) return;
+
+    TArray<int32> LocalAwake;
+    TArray<int32> LocalIslandSeed;
+    {
+        FScopeLock Lock(&DebugMutex);
+        LocalAwake = DebugData.BodyAwake;
+        LocalIslandSeed = DebugData.BodyIslandSeed;
+    }
+
+    auto ApplyToMesh = [&](UStaticMeshComponent* Mesh, int32 BodyId, uint32 GroupHash)
+    {
+        if (!Mesh) return;
+
+        const bool bAwake =
+            (LocalAwake.IsValidIndex(BodyId) ? LocalAwake[BodyId] != 0 : true);
+        const int32 Seed =
+            (LocalIslandSeed.IsValidIndex(BodyId) ? LocalIslandSeed[BodyId] : -1);
+
+        TWeakObjectPtr<UStaticMeshComponent> WeakMesh(Mesh);
+        const int32 NumSlots = FMath::Max(1, Mesh->GetNumMaterials());
+
+        if (!OriginalMaterials.Contains(WeakMesh))
+        {
+            OriginalMaterials.Add(WeakMesh, Mesh->GetMaterial(0));
+            for (int32 SlotIdx = 1; SlotIdx < NumSlots; ++SlotIdx)
+            {
+                OriginalSlotMaterials.FindOrAdd(WeakMesh).Add(SlotIdx, Mesh->GetMaterial(SlotIdx));
+            }
+        }
+
+        const bool bColourAsAwake = bAwake || !bModulateBySleep;
+        FLinearColor Color;
+        switch (DebugShaderMode)
+        {
+            case EMjDebugShaderMode::Island:
+                Color = MjColor::IslandColor(Seed, bColourAsAwake,
+                    SleepValueScale, SleepSaturationScale);
+                break;
+            case EMjDebugShaderMode::InstanceSegmentation:
+                Color = MjColor::InstanceSegmentationColor(GroupHash, BodyId, bColourAsAwake,
+                    SleepValueScale, SleepSaturationScale);
+                break;
+            case EMjDebugShaderMode::SemanticSegmentation:
+                Color = MjColor::SemanticSegmentationColor(GroupHash, bColourAsAwake,
+                    SleepValueScale, SleepSaturationScale);
+                break;
+            default:
+                return;
+        }
+
+        UMaterialInstanceDynamic* MID = nullptr;
+        if (UMaterialInstanceDynamic** Existing = ActiveMIDs.Find(WeakMesh))
+        {
+            MID = *Existing;
+        }
+        if (!MID)
+        {
+            MID = UMaterialInstanceDynamic::Create(OverlayParentMaterial, this);
+            ActiveMIDs.Add(WeakMesh, MID);
+        }
+
+        for (int32 SlotIdx = 0; SlotIdx < NumSlots; ++SlotIdx)
+        {
+            if (Mesh->GetMaterial(SlotIdx) != MID)
+            {
+                Mesh->SetMaterial(SlotIdx, MID);
+            }
+        }
+
+        MID->SetVectorParameterValue(OverlayColorParam, Color);
+    };
+
+    for (AMjArticulation* Art : Manager->GetAllArticulations())
+    {
+        if (!Art) continue;
+
+        // Semantic grouping hashes the Blueprint class so two instances share colour.
+        const uint32 ArtHash = GetTypeHash(Art->GetClass()->GetFName());
+
+        TArray<UMjGeom*> Geoms;
+        Art->GetRuntimeComponents<UMjGeom>(Geoms);
+        for (UMjGeom* Geom : Geoms)
+        {
+            if (!Geom || !Geom->IsBound()) continue;
+            const int32 BodyId = Geom->GetMj().body_id;
+
+            ApplyToMesh(Geom->GetVisualizerMesh(), BodyId, ArtHash);
+
+            TArray<USceneComponent*> Children;
+            Geom->GetChildrenComponents(true, Children);
+            for (USceneComponent* Child : Children)
+            {
+                if (UStaticMeshComponent* SMC = Cast<UStaticMeshComponent>(Child))
+                {
+                    ApplyToMesh(SMC, BodyId, ArtHash);
+                }
+            }
+        }
+    }
+
+    for (UMjQuickConvertComponent* QC : Manager->GetAllQuickComponents())
+    {
+        if (!QC) continue;
+        const int32 BodyId = QC->GetMjBodyId();
+        if (BodyId < 0) continue;
+
+        AActor* Owner = QC->GetOwner();
+        if (!Owner) continue;
+
+        TArray<UStaticMeshComponent*> MeshComps;
+        Owner->GetComponents<UStaticMeshComponent>(MeshComps);
+
+        // Semantic grouping hashes the first static mesh so props sharing a mesh read as one "type".
+        uint32 GroupHash = GetTypeHash(Owner->GetClass()->GetFName());
+        for (UStaticMeshComponent* SMC : MeshComps)
+        {
+            if (SMC && SMC->GetStaticMesh())
+            {
+                GroupHash = GetTypeHash(SMC->GetStaticMesh()->GetFName());
+                break;
+            }
+        }
+
+        for (UStaticMeshComponent* SMC : MeshComps)
+        {
+            ApplyToMesh(SMC, BodyId, GroupHash);
+        }
+    }
+}
+
+void UMjDebugVisualizer::InitializeOverlayMaterial()
+{
+    if (OverlayParentMaterial) return;
+
+    UMaterialInterface* Parent = LoadObject<UMaterialInterface>(
+        nullptr, TEXT("/Engine/BasicShapes/BasicShapeMaterial.BasicShapeMaterial"));
+
+    if (!Parent)
+    {
+        UE_LOG(LogURLab, Warning,
+            TEXT("Debug viz: failed to load /Engine/BasicShapes/BasicShapeMaterial — overlays disabled"));
+        return;
+    }
+
+    TArray<FMaterialParameterInfo> VecInfos;
+    TArray<FGuid> Guids;
+    Parent->GetAllVectorParameterInfo(VecInfos, Guids);
+
+    if (VecInfos.Num() == 0)
+    {
+        UE_LOG(LogURLab, Warning,
+            TEXT("Debug viz: BasicShapeMaterial exposes no vector params — overlays disabled"));
+        return;
+    }
+
+    // Prefer well-known colour-param names so we don't accidentally drive an emissive tint etc.
+    static const FName PreferredNames[] = {
+        TEXT("Color"), TEXT("BaseColor"), TEXT("Tint"), TEXT("TintColor"), TEXT("DiffuseColor")
+    };
+    FName Chosen = NAME_None;
+    for (const FName& Pref : PreferredNames)
+    {
+        for (const FMaterialParameterInfo& Info : VecInfos)
+        {
+            if (Info.Name == Pref) { Chosen = Pref; break; }
+        }
+        if (!Chosen.IsNone()) break;
+    }
+    if (Chosen.IsNone()) Chosen = VecInfos[0].Name;
+
+    OverlayParentMaterial = Parent;
+    OverlayColorParam = Chosen;
 }

--- a/Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp
@@ -77,6 +77,14 @@ void UMjInputHandler::ProcessHotkeys(APlayerController* PC)
     {
         if (Manager->DebugVisualizer) Manager->DebugVisualizer->ToggleQuickConvertCollisions();
     }
+    if (PC->WasInputKeyJustPressed(EKeys::Six))
+    {
+        if (Manager->DebugVisualizer) Manager->DebugVisualizer->CycleDebugShaderMode();
+    }
+    if (PC->WasInputKeyJustPressed(EKeys::Seven))
+    {
+        if (Manager->DebugVisualizer) Manager->DebugVisualizer->ToggleTendons();
+    }
 
     // P: Pause/Resume
     if (PC->WasInputKeyJustPressed(EKeys::P))

--- a/Source/URLab/Private/MuJoCo/Utils/MjColor.cpp
+++ b/Source/URLab/Private/MuJoCo/Utils/MjColor.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#include "MuJoCo/Utils/MjColor.h"
+
+namespace MjColor
+{
+    float Halton(int32 Seed, int32 Base)
+    {
+        float F = 1.0f;
+        float R = 0.0f;
+        int32 I = Seed;
+        while (I > 0)
+        {
+            F /= (float)Base;
+            R += F * (float)(I % Base);
+            I /= Base;
+        }
+        return R;
+    }
+
+    FLinearColor HSVToRGB(float H, float S, float V)
+    {
+        // Standard HSV -> RGB (matches MuJoCo's hsv2rgb).
+        H = FMath::Fmod(H, 1.0f);
+        if (H < 0.0f) H += 1.0f;
+        const float C = V * S;
+        const float Hp = H * 6.0f;
+        const float X = C * (1.0f - FMath::Abs(FMath::Fmod(Hp, 2.0f) - 1.0f));
+        float R = 0, G = 0, B = 0;
+        if      (Hp < 1) { R = C; G = X; }
+        else if (Hp < 2) { R = X; G = C; }
+        else if (Hp < 3) { G = C; B = X; }
+        else if (Hp < 4) { G = X; B = C; }
+        else if (Hp < 5) { R = X; B = C; }
+        else             { R = C; B = X; }
+        const float M = V - C;
+        return FLinearColor(R + M, G + M, B + M, 1.0f);
+    }
+
+    FLinearColor ApplySleepModulation(const FLinearColor& InColor, float SleepValueScale, float SleepSaturationScale)
+    {
+        // Re-derive HSV, dim value and desaturate, return RGB.
+        const float R = InColor.R, G = InColor.G, B = InColor.B;
+        const float Max = FMath::Max3(R, G, B);
+        const float Min = FMath::Min3(R, G, B);
+        const float V = Max;
+        const float S = (Max > 0.0f) ? (Max - Min) / Max : 0.0f;
+        float H = 0.0f;
+        const float Delta = Max - Min;
+        if (Delta > KINDA_SMALL_NUMBER)
+        {
+            if      (Max == R) H = FMath::Fmod((G - B) / Delta, 6.0f);
+            else if (Max == G) H = (B - R) / Delta + 2.0f;
+            else               H = (R - G) / Delta + 4.0f;
+            H /= 6.0f;
+            if (H < 0.0f) H += 1.0f;
+        }
+        return HSVToRGB(H, S * SleepSaturationScale, V * SleepValueScale);
+    }
+
+    FLinearColor IslandColor(int32 IslandId, bool bAwake, float SleepValueScale, float SleepSaturationScale)
+    {
+        // Match MuJoCo's islandColor() exactly. Upstream special-cases seed=-1
+        // (body not in any island and no tree fallback) to neutral grey 0.7.
+        if (IslandId < 0)
+        {
+            float V = 0.7f;
+            if (!bAwake) V *= SleepValueScale;
+            return FLinearColor(V, V, V);
+        }
+        // seed = id+1; Halton bases 7/3/5 -> HSV.
+        const int32 Seed = IslandId + 1;
+        const float H = Halton(Seed, 7);
+        float S = 0.5f + 0.5f * Halton(Seed, 3);
+        float V = 0.6f + 0.4f * Halton(Seed, 5);
+        if (!bAwake)
+        {
+            V *= SleepValueScale;
+            S *= SleepSaturationScale;
+        }
+        return HSVToRGB(H, S, V);
+    }
+
+    FLinearColor InstanceSegmentationColor(uint32 ArticulationHash, int32 BodyIndex, bool bAwake, float SleepValueScale, float SleepSaturationScale)
+    {
+        // Per-body unique colour via Halton, mixed with articulation hash so
+        // different articulations still diverge and adjacent bodies differ.
+        // +1 avoids Halton(0)=0 collapsing all channels.
+        const int32 Seed = (int32)((ArticulationHash * 2654435761u) ^ (uint32)BodyIndex) + 1;
+        const float H = Halton(Seed, 7);
+        float S = 0.5f + 0.5f * Halton(Seed, 3);
+        float V = 0.6f + 0.4f * Halton(Seed, 5);
+        if (!bAwake)
+        {
+            V *= SleepValueScale;
+            S *= SleepSaturationScale;
+        }
+        return HSVToRGB(H, S, V);
+    }
+
+    FLinearColor SemanticSegmentationColor(uint32 ArticulationHash, bool bAwake, float SleepValueScale, float SleepSaturationScale)
+    {
+        // All bodies of the same articulation/actor share this colour.
+        const int32 Seed = (int32)ArticulationHash + 1;
+        const float H = Halton(Seed, 7);
+        float S = 0.5f + 0.5f * Halton(Seed, 3);
+        float V = 0.6f + 0.4f * Halton(Seed, 5);
+        if (!bAwake)
+        {
+            V *= SleepValueScale;
+            S *= SleepSaturationScale;
+        }
+        return HSVToRGB(H, S, V);
+    }
+}

--- a/Source/URLab/Public/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h
+++ b/Source/URLab/Public/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h
@@ -112,6 +112,9 @@ public:
 
     /** @brief Returns proper body name. */
     FString GetBodyName();
+
+    /** @brief MuJoCo body id for this quick-converted actor, or -1 if not yet bound. */
+    int32 GetMjBodyId() const;
     
     /**
      * @brief Initializes the component, parsing meshes and adding to spec.

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugTypes.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugTypes.h
@@ -11,4 +11,14 @@ struct FMuJoCoDebugData
     TArray<FVector> ContactPoints;
     TArray<FVector> ContactNormals;
     TArray<float> ContactForces;
+
+    /** Per-body awake state snapshot (`mjData.body_awake`), size nbody. 0 = asleep. */
+    TArray<int32> BodyAwake;
+
+    /**
+     * Halton colour seed per body. `island_dofadr[island]` when in an active
+     * constraint island, else `tree_dofadr[tree]` (with `mj_sleepCycle` when
+     * asleep). -1 means "don't colour" (e.g. worldbody). Size nbody.
+     */
+    TArray<int32> BodyIslandSeed;
 };

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
@@ -29,7 +29,18 @@
 
 // Forward declarations
 class AAMjManager;
+class UMaterialInterface;
 struct FMuJoCoDebugData;
+
+/** Per-body visual overlay mode applied during PIE. */
+UENUM(BlueprintType)
+enum class EMjDebugShaderMode : uint8
+{
+    Off                     UMETA(DisplayName="Off"),
+    Island                  UMETA(DisplayName="Constraint Islands"),
+    InstanceSegmentation    UMETA(DisplayName="Instance Segmentation (per-body)"),
+    SemanticSegmentation    UMETA(DisplayName="Semantic Segmentation (per-actor)")
+};
 
 /**
  * @class UMjDebugVisualizer
@@ -43,6 +54,7 @@ class URLAB_API UMjDebugVisualizer : public UActorComponent
 public:
     UMjDebugVisualizer();
 
+    virtual void BeginPlay() override;
     virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
     // --- Debug rendering params ---
@@ -85,6 +97,26 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Interp, Category = "MuJoCo|Debug")
     bool bGlobalQuickConvertCollision = false;
 
+    /** @brief Per-body overlay shader mode (Island / Segmentation / Off). Cycled via key 6. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug")
+    EMjDebugShaderMode DebugShaderMode = EMjDebugShaderMode::Off;
+
+    /** @brief When true, sleeping bodies are dimmed + desaturated on top of the active shader mode. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug")
+    bool bModulateBySleep = true;
+
+    /** @brief Value (brightness) multiplier applied to sleeping bodies. MuJoCo upstream uses 0.6; default 0.35 dims clearly while keeping hue visible. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.05", ClampMax="1.0"))
+    float SleepValueScale = 0.35f;
+
+    /** @brief Saturation multiplier applied to sleeping bodies. Keep high to preserve hue identity; lower toward 0 to desaturate sleeping bodies to grey. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.0", ClampMax="1.0"))
+    float SleepSaturationScale = 0.9f;
+
+    /** @brief Toggles tendon/muscle spline-mesh rendering. Toggled via key 7. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug")
+    bool bGlobalDrawTendons = false;
+
     // --- Thread-safe debug data ---
     FMuJoCoDebugData DebugData;
     FCriticalSection DebugMutex;
@@ -112,6 +144,39 @@ public:
     /** @brief Toggle visual mesh visibility on all articulations (key: 2). */
     void ToggleVisuals();
 
+    /** @brief Cycle per-body shader overlay: Off -> Island -> Segmentation -> Off (key: 6). */
+    void CycleDebugShaderMode();
+
+    /** @brief Toggle tendon/muscle spline rendering (key: 7). */
+    void ToggleTendons();
+
+    /** @brief Parent material for body/tendon overlay MIDs, probed from engine content at BeginPlay. */
+    UPROPERTY(Transient)
+    UMaterialInterface* OverlayParentMaterial = nullptr;
+
+    /** @brief Vector parameter name on OverlayParentMaterial that accepts the overlay colour. */
+    FName OverlayColorParam = NAME_None;
+
+    /** @brief Loads /Engine/BasicShapes/BasicShapeMaterial and records the first vector param name. */
+    void InitializeOverlayMaterial();
+
+    /** @brief Apply per-body overlay MIDs based on DebugShaderMode, or restore originals if Off. */
+    void UpdateBodyOverlays();
+
+    /** @brief Restore original materials recorded at overlay apply time, clear caches. */
+    void ClearBodyOverlays();
+
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
 private:
     bool bVisualsHidden = false;
+
+    /** Original slot-0 material on meshes we've overridden, so we can restore. Keyed by mesh component. */
+    TMap<TWeakObjectPtr<class UStaticMeshComponent>, class UMaterialInterface*> OriginalMaterials;
+
+    /** Original slot-1..N materials for multi-material meshes. Parallel to OriginalMaterials. */
+    TMap<TWeakObjectPtr<class UStaticMeshComponent>, TMap<int32, class UMaterialInterface*>> OriginalSlotMaterials;
+
+    /** Dynamic material instances we created per mesh, reused across ticks. */
+    TMap<TWeakObjectPtr<class UStaticMeshComponent>, class UMaterialInstanceDynamic*> ActiveMIDs;
 };

--- a/Source/URLab/Public/MuJoCo/Utils/MjColor.h
+++ b/Source/URLab/Public/MuJoCo/Utils/MjColor.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Colour helpers matching MuJoCo's upstream visualizer (engine_vis_visualize.c).
+ * Used by UMjDebugVisualizer to paint bodies in Island / Segmentation modes.
+ */
+namespace MjColor
+{
+    /** Radical-inverse (van der Corput / Halton) for a given integer seed and prime base. */
+    URLAB_API float Halton(int32 Seed, int32 Base);
+
+    /** HSV -> linear RGB. h,s,v all in [0,1]. */
+    URLAB_API FLinearColor HSVToRGB(float H, float S, float V);
+
+    /**
+     * MuJoCo's `islandColor()` formula, with optional sleep modulation.
+     * hue = halton(id+1, 7); sat = 0.5 + 0.5*halton(id+1, 3); val = 0.6 + 0.4*halton(id+1, 5).
+     * If !awake: val *= ValueScale, sat *= SaturationScale (MuJoCo upstream uses 0.6, 0.7).
+     */
+    URLAB_API FLinearColor IslandColor(int32 IslandId, bool bAwake, float SleepValueScale = 0.35f, float SleepSaturationScale = 0.9f);
+
+    /**
+     * Instance segmentation — each body gets a unique Halton-keyed colour,
+     * distinct even within the same articulation.
+     */
+    URLAB_API FLinearColor InstanceSegmentationColor(uint32 ArticulationHash, int32 BodyIndex, bool bAwake, float SleepValueScale = 0.35f, float SleepSaturationScale = 0.9f);
+
+    /**
+     * Semantic segmentation — every body owned by the same actor (articulation
+     * or Quick-Convert component) shares a single Halton-keyed colour.
+     */
+    URLAB_API FLinearColor SemanticSegmentationColor(uint32 ArticulationHash, bool bAwake, float SleepValueScale = 0.35f, float SleepSaturationScale = 0.9f);
+
+    /** Apply the sleep modulation (val*=ValueScale, sat*=SaturationScale) to an existing linear-RGB colour. */
+    URLAB_API FLinearColor ApplySleepModulation(const FLinearColor& InColor, float SleepValueScale = 0.35f, float SleepSaturationScale = 0.9f);
+}

--- a/Source/URLabEditor/Private/Tests/MjColorTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjColorTests.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "MuJoCo/Utils/MjColor.h"
+
+// Halton base-2 sequence: 1/2, 1/4, 3/4, 1/8, 5/8, 3/8, 7/8...
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorHaltonBase2,
+    "URLab.Color.Halton_Base2",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorHaltonBase2::RunTest(const FString& Parameters)
+{
+    const float Expected[] = { 0.5f, 0.25f, 0.75f, 0.125f, 0.625f, 0.375f, 0.875f };
+    for (int32 i = 0; i < UE_ARRAY_COUNT(Expected); ++i)
+    {
+        const float V = MjColor::Halton(i + 1, 2);
+        TestTrue(FString::Printf(TEXT("Halton(%d,2) ~= %f"), i + 1, Expected[i]),
+            FMath::IsNearlyEqual(V, Expected[i], 1e-5f));
+    }
+    return true;
+}
+
+// Halton(0, base) must return 0 and never loop forever.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorHaltonZero,
+    "URLab.Color.Halton_Zero",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorHaltonZero::RunTest(const FString& Parameters)
+{
+    TestTrue(TEXT("Halton(0,7) == 0"), FMath::IsNearlyZero(MjColor::Halton(0, 7)));
+    return true;
+}
+
+// HSV(0,0,V) should produce pure grey regardless of hue.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorHSVGrey,
+    "URLab.Color.HSV_ZeroSaturationGivesGrey",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorHSVGrey::RunTest(const FString& Parameters)
+{
+    const FLinearColor C = MjColor::HSVToRGB(0.37f, 0.0f, 0.5f);
+    TestTrue(TEXT("R ~= G"), FMath::IsNearlyEqual(C.R, C.G, 1e-5f));
+    TestTrue(TEXT("G ~= B"), FMath::IsNearlyEqual(C.G, C.B, 1e-5f));
+    TestTrue(TEXT("V ~= 0.5"), FMath::IsNearlyEqual(C.R, 0.5f, 1e-5f));
+    return true;
+}
+
+// HSV primaries round-trip: H=0 -> pure red.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorHSVPrimaries,
+    "URLab.Color.HSV_Primaries",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorHSVPrimaries::RunTest(const FString& Parameters)
+{
+    const FLinearColor Red = MjColor::HSVToRGB(0.0f, 1.0f, 1.0f);
+    TestTrue(TEXT("Red.R=1"), FMath::IsNearlyEqual(Red.R, 1.0f, 1e-5f));
+    TestTrue(TEXT("Red.G=0"), FMath::IsNearlyZero(Red.G, 1e-5f));
+    TestTrue(TEXT("Red.B=0"), FMath::IsNearlyZero(Red.B, 1e-5f));
+
+    const FLinearColor Green = MjColor::HSVToRGB(1.0f/3.0f, 1.0f, 1.0f);
+    TestTrue(TEXT("Green.G=1"), FMath::IsNearlyEqual(Green.G, 1.0f, 1e-4f));
+    TestTrue(TEXT("Green.R=0"), FMath::IsNearlyZero(Green.R, 1e-4f));
+
+    const FLinearColor Blue = MjColor::HSVToRGB(2.0f/3.0f, 1.0f, 1.0f);
+    TestTrue(TEXT("Blue.B=1"), FMath::IsNearlyEqual(Blue.B, 1.0f, 1e-4f));
+    TestTrue(TEXT("Blue.R=0"), FMath::IsNearlyZero(Blue.R, 1e-4f));
+    return true;
+}
+
+// Sleep modulation: saturation and value must shrink, hue preserved.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorSleepModulation,
+    "URLab.Color.SleepModulationDimsAndDesaturates",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorSleepModulation::RunTest(const FString& Parameters)
+{
+    // Start with a vivid saturated red: HSV(0, 1, 1). Pass explicit scales
+    // so the test is independent of the default knob values.
+    const FLinearColor Awake = MjColor::HSVToRGB(0.0f, 1.0f, 1.0f);
+    const FLinearColor Asleep = MjColor::ApplySleepModulation(Awake, 0.6f, 0.7f);
+
+    // Value (max channel) should drop from 1.0 to ~0.6.
+    const float AwakeMax = FMath::Max3(Awake.R, Awake.G, Awake.B);
+    const float AsleepMax = FMath::Max3(Asleep.R, Asleep.G, Asleep.B);
+    TestTrue(TEXT("Value dimmed"), FMath::IsNearlyEqual(AsleepMax, AwakeMax * 0.6f, 1e-4f));
+
+    // Desaturation: min channel should rise (grey component added).
+    TestTrue(TEXT("Min channel increased"),
+        FMath::Min3(Asleep.R, Asleep.G, Asleep.B) >= FMath::Min3(Awake.R, Awake.G, Awake.B) - 1e-4f);
+    return true;
+}
+
+// Island colors are deterministic for the same (id, awake) pair.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorIslandDeterministic,
+    "URLab.Color.IslandColor_Deterministic",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorIslandDeterministic::RunTest(const FString& Parameters)
+{
+    for (int32 i = 0; i < 10; ++i)
+    {
+        const FLinearColor A = MjColor::IslandColor(i, true);
+        const FLinearColor B = MjColor::IslandColor(i, true);
+        TestTrue(TEXT("Same id, same awake -> same color"), A.Equals(B, 1e-5f));
+    }
+    return true;
+}
+
+// Sleep modulation on IslandColor visibly changes max channel.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjColorIslandSleepDiffers,
+    "URLab.Color.IslandColor_SleepDiffers",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjColorIslandSleepDiffers::RunTest(const FString& Parameters)
+{
+    const FLinearColor Awake = MjColor::IslandColor(3, true);
+    const FLinearColor Asleep = MjColor::IslandColor(3, false);
+    const float AwakeMax = FMath::Max3(Awake.R, Awake.G, Awake.B);
+    const float AsleepMax = FMath::Max3(Asleep.R, Asleep.G, Asleep.B);
+    TestTrue(TEXT("Asleep is dimmer than awake"), AsleepMax < AwakeMax - 1e-3f);
+    return true;
+}


### PR DESCRIPTION
Adds a per-body shader overlay that runs during PIE, matching MuJoCo's native visualiser. Key **6** cycles through:

- **Off** — restore original materials.
- **Island** — Halton-HSV colour per constraint island, reusing MuJoCo's exact `islandColor()` algorithm (DOF-adr seed via `island_dofadr[island]`, with kinematic-tree fallback and `mj_sleepCycle` for sleeping bodies so groups that sleep together stay one colour).
- **Instance Segmentation** — unique Halton colour per body.
- **Semantic Segmentation** — one colour per Blueprint class (articulations) or static-mesh asset (Quick-Convert props), so N instances of the same robot all read as the same colour.

Sleep modulation is an always-on overlay on top of the active mode (`V *= 0.35`, `S *= 0.9` by default), tunable live on the `UMjDebugVisualizer` Details panel. Articulation primitive geoms, imported mesh geoms (all material slots), and Quick-Convert actors are all painted.

No custom `.uasset` material is introduced — uses engine-shipped `/Engine/BasicShapes/BasicShapeMaterial` with a runtime param probe that picks a well-known colour vector name.

Tendon/muscle rendering is wired in scaffolding (key **7** toggle) but deferred to a follow-up commit on this branch: the XML import pipeline has a separate issue where tendons don't survive the articulation's child spec → root spec merge, so muscles compile with `nu=0`. Will be investigated.