### PR TITLE
Tendon/muscle import fixes + activation-driven tube visualization

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Actuators/MjMuscleActuator.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Actuators/MjMuscleActuator.cpp
@@ -83,26 +83,24 @@ void UMjMuscleActuator::ExportTo(mjsActuator* act, mjsDefault* def)
 {
     if (!act) return;
 
-    double tc[2] = { 
+    Super::ExportTo(act, def);
+
+    // mjs_setToMuscle dereferences timeconst[0..1] and range[0..1] unconditionally,
+    // treating -1 as the "not overridden — leave alone" sentinel. Never pass null.
+    // `range` here is the muscle-specific length range (gainprm[0..1] = lrmin, lrmax),
+    // NOT the actuator's ctrlrange — passing ctrlrange here would clobber the
+    // muscle defaults (0.75, 1.05). We don't yet expose this as a UPROPERTY, so
+    // pass the sentinel to keep MuJoCo's built-in muscle defaults.
+    double timeconst[2] = {
         bOverride_TimeConst  ? (double)TimeConst  : -1.0,
         bOverride_TimeConst2 ? (double)TimeConst2 : -1.0
     };
-    // MuJoCo mjs_setToMuscle: pass nullptr timeconst to use defaults from spec/defaults
-    double* timeconst_ptr = (bOverride_TimeConst || bOverride_TimeConst2) ? tc : nullptr;
+    double range[2] = { -1.0, -1.0 };
 
-    // range: MuJoCo uses {-1,-1} sentinel for "not specified". Use CtrlRange if set.
-    double range[2] = {
-        bOverride_CtrlRange && CtrlRange.Num() > 0 ? (double)CtrlRange[0] : -1.0,
-        bOverride_CtrlRange && CtrlRange.Num() > 1 ? (double)CtrlRange[1] : -1.0
-    };
-
-    Super::ExportTo(act, def); // 1. Common attributes (populates act from default via mjs_addActuator)
-
-    // Mirror OneActuator: tausmooth = act->dynprm[2] as inherited default, override only if explicitly set.
     const double tausmooth = bOverride_TauSmooth ? (double)TauSmooth : act->dynprm[2];
 
-    mjs_setToMuscle(act,           // 2. Type preset
-        timeconst_ptr,
+    mjs_setToMuscle(act,
+        timeconst,
         tausmooth,
         range,
         bOverride_Force  ? (double)Force  : -1.0,
@@ -112,5 +110,6 @@ void UMjMuscleActuator::ExportTo(mjsActuator* act, mjsDefault* def)
         bOverride_VMax   ? (double)VMax   : -1.0,
         bOverride_FPMax  ? (double)FPMax  : -1.0,
         bOverride_FVMax  ? (double)FVMax  : -1.0);
-    ApplyRawOverrides(act, def);   // 3. Raw prm overrides
+
+    ApplyRawOverrides(act, def);
 }

--- a/Source/URLab/Private/MuJoCo/Components/Defaults/MjDefault.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Defaults/MjDefault.cpp
@@ -73,7 +73,6 @@ void UMjDefault::ExportTo(mjsDefault* def)
         }
         else if (UMjActuator* ActuatorComp = Cast<UMjActuator>(Child))
         {
-            // Export to def->actuator (handles subclass-specific properties natively via virtual ExportTo)
             ActuatorComp->ExportTo(def->actuator, nullptr);
             UE_LOG(LogURLabWrapper, Verbose, TEXT("  - [Actuator] Exported actuator defaults from %s"), *ActuatorComp->GetName());
         }

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
@@ -530,7 +530,7 @@ void UMjGeom::RegisterToSpec(FMujocoSpecWrapper& Wrapper, mjsBody* ParentBody)
     m_SpecElement = geom->element;
 
     FString NameToRegister = MjName.IsEmpty() ? GetName() : MjName;
-    FString UniqueName = Wrapper.GetUniqueName(GetName(), mjOBJ_GEOM, GetOwner());
+    FString UniqueName = Wrapper.GetUniqueName(NameToRegister, mjOBJ_GEOM, GetOwner());
     mjs_setName(geom->element, TCHAR_TO_UTF8(*UniqueName));
     MjName = UniqueName;
 

--- a/Source/URLab/Private/MuJoCo/Components/Joints/MjJoint.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Joints/MjJoint.cpp
@@ -105,10 +105,19 @@ void UMjJoint::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& Co
     // compiler (mjLIMITED_AUTO default). We do not replicate that logic here.
     MjXmlUtils::ReadAttrFloatArray(Node, TEXT("range"), Range, bOverride_Range);
 
-    // Slide joints: convert range from meters to cm (UE units)
-    if (bOverride_Range && Type == EMjJointType::Slide)
+    if (bOverride_Range)
     {
-        for (float& V : Range) V *= 100.0f;
+        if (Type == EMjJointType::Slide)
+        {
+            // Slide joints: MJCF stores metres, UE units are cm.
+            for (float& V : Range) V *= 100.0f;
+        }
+        else if (CompilerSettings.bAngleInDegrees)
+        {
+            // Hinge/ball joint ranges in MJCF are in the compiler angle units.
+            // Our spec is compiled with radians, so convert here to match.
+            for (float& V : Range) V = FMath::DegreesToRadians(V);
+        }
     }
 
     MjXmlUtils::ReadAttrFloatArray(Node, TEXT("actuatorfrcrange"), ActuatorFrcRange, bOverride_ActuatorFrcRange);

--- a/Source/URLab/Private/MuJoCo/Core/MjArticulation.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjArticulation.cpp
@@ -295,6 +295,27 @@ void AMjArticulation::Setup(mjSpec* Spec, mjVFS* VFS)
           }
      }
 
+     // Worldbody-level IMjSpecElement children (sites, etc. attached directly to
+     // <worldbody>) need to register against the child spec's world body so
+     // downstream references (tendons wrapping worldbody sites, for instance)
+     // resolve at compile time.
+     mjsBody* ChildWorld = mjs_findBody(m_ChildSpec, "world");
+     if (ChildWorld)
+     {
+          for (USceneComponent* Child : WorldChildren)
+          {
+               if (Cast<UMjBody>(Child) || Cast<UMjFrame>(Child)) continue;
+               if (UMjComponent* MjComp = Cast<UMjComponent>(Child))
+               {
+                    if (MjComp->bIsDefault) continue;
+                    if (IMjSpecElement* SpecElem = Cast<IMjSpecElement>(Child))
+                    {
+                         SpecElem->RegisterToSpec(*m_wrapper, ChildWorld);
+                    }
+               }
+          }
+     }
+
     // 4. Add Tendons (into child spec, after bodies so joint names are set)
     TArray<UMjTendon*> Tendons;
     GetComponents<UMjTendon>(Tendons);

--- a/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
@@ -50,6 +50,11 @@ void UMjDebugVisualizer::TickComponent(float DeltaTime, ELevelTick TickType, FAc
 
     UpdateBodyOverlays();
 
+    if (bGlobalDrawTendons)
+    {
+        DrawTendonLines();
+    }
+
     if (!bShowDebug) return;
 
     FMuJoCoDebugData LocalDebugData;
@@ -165,6 +170,44 @@ void UMjDebugVisualizer::CaptureDebugData()
         }
 
         DebugData.BodyIslandSeed[b] = H;
+    }
+
+    // Tendon wrap points — mirror MuJoCo's own renderer (engine_vis_visualize.c
+    // addSpatialTendonGeoms). It iterates wrap-point index j from ten_wrapadr[t]
+    // to ...+ten_wrapnum[t]-1 and connects wrap_xpos[3*j] -> wrap_xpos[3*j+3],
+    // skipping pulleys (wrap_obj == -2). Declared layout is `nwrap x 6` so we
+    // snapshot 2*nwrap 3D points.
+    const int32 NumWrapPoints = 2 * Model->nwrap;
+    DebugData.WrapPointsFlat.SetNumUninitialized(NumWrapPoints);
+    if (Data->wrap_xpos && Model->nwrap > 0)
+    {
+        for (int32 p = 0; p < NumWrapPoints; ++p)
+        {
+            DebugData.WrapPointsFlat[p] = MjUtils::MjToUEPosition(Data->wrap_xpos + p * 3);
+        }
+    }
+
+    const int32 NumWrapObj = 2 * Model->nwrap;
+    DebugData.WrapObj.SetNumUninitialized(NumWrapObj);
+    if (Data->wrap_obj && Model->nwrap > 0)
+    {
+        for (int32 i = 0; i < NumWrapObj; ++i) DebugData.WrapObj[i] = Data->wrap_obj[i];
+    }
+
+    DebugData.TendonWrapAdr.SetNumUninitialized(Model->ntendon);
+    DebugData.TendonWrapNum.SetNumUninitialized(Model->ntendon);
+    DebugData.TendonLength.SetNumUninitialized(Model->ntendon);
+    DebugData.TendonLimited.SetNumUninitialized(Model->ntendon);
+    DebugData.TendonRangeLo.SetNumUninitialized(Model->ntendon);
+    DebugData.TendonRangeHi.SetNumUninitialized(Model->ntendon);
+    for (int32 t = 0; t < Model->ntendon; ++t)
+    {
+        DebugData.TendonWrapAdr[t]  = Data->ten_wrapadr ? Data->ten_wrapadr[t] : 0;
+        DebugData.TendonWrapNum[t]  = Data->ten_wrapnum ? Data->ten_wrapnum[t] : 0;
+        DebugData.TendonLength[t]   = Data->ten_length ? (float)Data->ten_length[t] : 0.0f;
+        DebugData.TendonLimited[t]  = Model->tendon_limited ? Model->tendon_limited[t] : 0;
+        DebugData.TendonRangeLo[t]  = Model->tendon_range ? (float)Model->tendon_range[t * 2 + 0] : 0.0f;
+        DebugData.TendonRangeHi[t]  = Model->tendon_range ? (float)Model->tendon_range[t * 2 + 1] : 0.0f;
     }
 }
 
@@ -457,6 +500,61 @@ void UMjDebugVisualizer::UpdateBodyOverlays()
         for (UStaticMeshComponent* SMC : MeshComps)
         {
             ApplyToMesh(SMC, BodyId, GroupHash);
+        }
+    }
+}
+
+void UMjDebugVisualizer::DrawTendonLines()
+{
+    UWorld* World = GetWorld();
+    if (!World) return;
+
+    TArray<FVector> LocalPoints;
+    TArray<int32> LocalWrapObj, LocalAdr, LocalNum;
+    TArray<float> LocalLengths, LocalLo, LocalHi;
+    TArray<uint8> LocalLimited;
+    {
+        FScopeLock Lock(&DebugMutex);
+        LocalPoints = DebugData.WrapPointsFlat;
+        LocalWrapObj = DebugData.WrapObj;
+        LocalAdr = DebugData.TendonWrapAdr;
+        LocalNum = DebugData.TendonWrapNum;
+        LocalLengths = DebugData.TendonLength;
+        LocalLimited = DebugData.TendonLimited;
+        LocalLo = DebugData.TendonRangeLo;
+        LocalHi = DebugData.TendonRangeHi;
+    }
+
+    const int32 NumTendons = LocalAdr.Num();
+    for (int32 t = 0; t < NumTendons; ++t)
+    {
+        float Stretch = 0.5f;
+        if (LocalLimited.IsValidIndex(t) && LocalLimited[t])
+        {
+            const float Len = LocalLengths[t];
+            const float Lo = LocalLo[t];
+            const float Hi = LocalHi[t];
+            if (Hi > Lo + KINDA_SMALL_NUMBER)
+            {
+                Stretch = FMath::Clamp((Len - Lo) / (Hi - Lo), 0.0f, 1.0f);
+            }
+        }
+        const FColor LineColor = FLinearColor::LerpUsingHSV(
+            FLinearColor::Blue, FLinearColor::Red, Stretch).ToFColor(false);
+
+        const int32 Adr = LocalAdr[t];
+        const int32 Num = LocalNum[t];
+        // Mirror MuJoCo's engine_vis_visualize.c: for each consecutive wrap
+        // index pair (j, j+1), skip pulley endpoints (wrap_obj == -2), then
+        // connect wrap_xpos[3*j] -> wrap_xpos[3*j + 3].
+        for (int32 j = Adr; j + 1 < Adr + Num; ++j)
+        {
+            if (LocalWrapObj.IsValidIndex(j)     && LocalWrapObj[j]     == -2) continue;
+            if (LocalWrapObj.IsValidIndex(j + 1) && LocalWrapObj[j + 1] == -2) continue;
+            if (!LocalPoints.IsValidIndex(j + 1)) continue;
+            const FVector& A = LocalPoints[j];
+            const FVector& B = LocalPoints[j + 1];
+            DrawDebugLine(World, A, B, LineColor, false, -1.0f, 0, TendonLineThickness);
         }
     }
 }

--- a/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
@@ -29,6 +29,8 @@
 #include "MuJoCo/Components/Geometry/MjGeom.h"
 #include "MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h"
 #include "DrawDebugHelpers.h"
+#include "Components/SplineMeshComponent.h"
+#include "Engine/StaticMesh.h"
 #include "Materials/MaterialInterface.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Utils/URLabLogging.h"
@@ -42,6 +44,12 @@ void UMjDebugVisualizer::BeginPlay()
 {
     Super::BeginPlay();
     InitializeOverlayMaterial();
+    TendonTubeMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Cylinder.Cylinder"));
+    if (!TendonTubeMesh)
+    {
+        UE_LOG(LogURLab, Warning,
+            TEXT("Debug viz: could not load /Engine/BasicShapes/Cylinder — tendon tubes will be invisible."));
+    }
 }
 
 void UMjDebugVisualizer::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
@@ -52,7 +60,11 @@ void UMjDebugVisualizer::TickComponent(float DeltaTime, ELevelTick TickType, FAc
 
     if (bGlobalDrawTendons)
     {
-        DrawTendonLines();
+        UpdateTendonTubes();
+    }
+    else
+    {
+        HideTendonTubes();
     }
 
     if (!bShowDebug) return;
@@ -200,6 +212,7 @@ void UMjDebugVisualizer::CaptureDebugData()
     DebugData.TendonLimited.SetNumUninitialized(Model->ntendon);
     DebugData.TendonRangeLo.SetNumUninitialized(Model->ntendon);
     DebugData.TendonRangeHi.SetNumUninitialized(Model->ntendon);
+    DebugData.TendonActivation.Init(-1.0f, Model->ntendon);
     for (int32 t = 0; t < Model->ntendon; ++t)
     {
         DebugData.TendonWrapAdr[t]  = Data->ten_wrapadr ? Data->ten_wrapadr[t] : 0;
@@ -208,6 +221,27 @@ void UMjDebugVisualizer::CaptureDebugData()
         DebugData.TendonLimited[t]  = Model->tendon_limited ? Model->tendon_limited[t] : 0;
         DebugData.TendonRangeLo[t]  = Model->tendon_range ? (float)Model->tendon_range[t * 2 + 0] : 0.0f;
         DebugData.TendonRangeHi[t]  = Model->tendon_range ? (float)Model->tendon_range[t * 2 + 1] : 0.0f;
+    }
+
+    // Resolve muscle activation per tendon by scanning actuators. Muscles drive
+    // tendons via trntype == TENDON; act[actadr] holds activation in [0, 1].
+    for (int32 a = 0; a < Model->nu; ++a)
+    {
+        if (Model->actuator_trntype[a] != mjTRN_TENDON) continue;
+        if (Model->actuator_dyntype[a] != mjDYN_MUSCLE) continue;
+        const int32 TargetTendon = Model->actuator_trnid[a * 2];
+        const int32 ActAdr = Model->actuator_actadr ? Model->actuator_actadr[a] : -1;
+        if (TargetTendon < 0 || TargetTendon >= Model->ntendon) continue;
+        if (ActAdr < 0 || !Data->act) continue;
+        DebugData.TendonActivation[TargetTendon] = FMath::Clamp((float)Data->act[ActAdr], 0.0f, 1.0f);
+    }
+
+    DebugData.GeomXPos.SetNumUninitialized(Model->ngeom);
+    for (int32 g = 0; g < Model->ngeom; ++g)
+    {
+        DebugData.GeomXPos[g] = Data->geom_xpos
+            ? MjUtils::MjToUEPosition(Data->geom_xpos + g * 3)
+            : FVector::ZeroVector;
     }
 }
 
@@ -338,6 +372,7 @@ void UMjDebugVisualizer::ToggleTendons()
 void UMjDebugVisualizer::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
     ClearBodyOverlays();
+    ClearTendonTubes();
     Super::EndPlay(EndPlayReason);
 }
 
@@ -504,15 +539,81 @@ void UMjDebugVisualizer::UpdateBodyOverlays()
     }
 }
 
-void UMjDebugVisualizer::DrawTendonLines()
+void UMjDebugVisualizer::HideTendonTubes()
 {
-    UWorld* World = GetWorld();
-    if (!World) return;
+    for (USplineMeshComponent* Seg : TendonSegmentPool)
+    {
+        if (Seg) Seg->SetVisibility(false);
+    }
+}
+
+void UMjDebugVisualizer::ClearTendonTubes()
+{
+    for (USplineMeshComponent* Seg : TendonSegmentPool)
+    {
+        if (Seg) Seg->DestroyComponent();
+    }
+    TendonSegmentPool.Reset();
+    TendonSegmentMIDs.Reset();
+}
+
+namespace
+{
+    // `/Engine/BasicShapes/Cylinder.Cylinder` ships as a 100cm-tall unit cylinder
+    // with 50cm base radius. USplineMeshComponent::SetStartScale multiplies the
+    // cross-section (X/Y) by its arg, so to get a visible radius in cm we divide
+    // by this constant. Kept local since we're the only caller.
+    constexpr float kBasicCylinderBaseRadiusCm = 50.0f;
+
+    FVector ComputeJoinTangent(const FVector& PrevDir, float PrevLen,
+                               const FVector& NextDir, float NextLen)
+    {
+        const FVector Avg = (PrevDir + NextDir).GetSafeNormal();
+        const float Scale = 0.5f * (PrevLen + NextLen);
+        return Avg * Scale;
+    }
+
+    // Spherical lerp about a shared origin — exact for sphere wraps, good enough
+    // for cylinder wraps where both wrap points share the same perpendicular
+    // distance from the cylinder axis.
+    FVector SlerpAboutCentre(const FVector& Centre, const FVector& VA, const FVector& VB, float T)
+    {
+        const float LenA = VA.Length();
+        const float LenB = VB.Length();
+        if (LenA < KINDA_SMALL_NUMBER || LenB < KINDA_SMALL_NUMBER)
+        {
+            return Centre + FMath::Lerp(VA, VB, T);
+        }
+        const FVector UA = VA / LenA;
+        const FVector UB = VB / LenB;
+        const float CosTheta = FMath::Clamp(FVector::DotProduct(UA, UB), -1.0f, 1.0f);
+        const float Theta = FMath::Acos(CosTheta);
+        if (Theta < 1e-3f)
+        {
+            return Centre + FMath::Lerp(VA, VB, T);
+        }
+        const float Radius = FMath::Lerp(LenA, LenB, T);
+        const float SinTheta = FMath::Sin(Theta);
+        const float WA = FMath::Sin((1.0f - T) * Theta) / SinTheta;
+        const float WB = FMath::Sin(T * Theta) / SinTheta;
+        return Centre + (UA * WA + UB * WB) * Radius;
+    }
+}
+
+void UMjDebugVisualizer::UpdateTendonTubes()
+{
+    AActor* Owner = GetOwner();
+    if (!Owner || !TendonTubeMesh || !OverlayParentMaterial || OverlayColorParam.IsNone())
+    {
+        HideTendonTubes();
+        return;
+    }
 
     TArray<FVector> LocalPoints;
     TArray<int32> LocalWrapObj, LocalAdr, LocalNum;
-    TArray<float> LocalLengths, LocalLo, LocalHi;
+    TArray<float> LocalLengths, LocalLo, LocalHi, LocalActivation;
     TArray<uint8> LocalLimited;
+    TArray<FVector> LocalGeomPos;
     {
         FScopeLock Lock(&DebugMutex);
         LocalPoints = DebugData.WrapPointsFlat;
@@ -523,38 +624,159 @@ void UMjDebugVisualizer::DrawTendonLines()
         LocalLimited = DebugData.TendonLimited;
         LocalLo = DebugData.TendonRangeLo;
         LocalHi = DebugData.TendonRangeHi;
+        LocalActivation = DebugData.TendonActivation;
+        LocalGeomPos = DebugData.GeomXPos;
     }
+
+    struct FTubeSeg
+    {
+        FVector Start;
+        FVector End;
+        FVector StartTangent;
+        FVector EndTangent;
+        FLinearColor Colour;
+        float Radius;     // visible radius in cm
+    };
+    TArray<FTubeSeg> Segs;
+    Segs.Reserve(LocalPoints.Num() * 2);
 
     const int32 NumTendons = LocalAdr.Num();
     for (int32 t = 0; t < NumTendons; ++t)
     {
-        float Stretch = 0.5f;
-        if (LocalLimited.IsValidIndex(t) && LocalLimited[t])
+        // Intensity: activation for muscles, length-vs-range stretch for limited tendons, else neutral.
+        float Intensity = 0.5f;
+        const float Act = LocalActivation.IsValidIndex(t) ? LocalActivation[t] : -1.0f;
+        if (Act >= 0.0f)
         {
-            const float Len = LocalLengths[t];
+            Intensity = Act;
+        }
+        else if (LocalLimited.IsValidIndex(t) && LocalLimited[t])
+        {
             const float Lo = LocalLo[t];
             const float Hi = LocalHi[t];
             if (Hi > Lo + KINDA_SMALL_NUMBER)
             {
-                Stretch = FMath::Clamp((Len - Lo) / (Hi - Lo), 0.0f, 1.0f);
+                Intensity = FMath::Clamp((LocalLengths[t] - Lo) / (Hi - Lo), 0.0f, 1.0f);
             }
         }
-        const FColor LineColor = FLinearColor::LerpUsingHSV(
-            FLinearColor::Blue, FLinearColor::Red, Stretch).ToFColor(false);
+        const FLinearColor Colour = FLinearColor::LerpUsingHSV(
+            FLinearColor(0.05f, 0.05f, 0.6f), FLinearColor(1.0f, 0.15f, 0.05f), Intensity);
+        // Swell more dramatically — 0.5× relaxed, 2× fully contracted (4× range).
+        const float Radius = TendonTubeRadius * (0.5f + 1.5f * Intensity);
 
+        // Build ordered path with optional arc subdivision across geom wraps.
+        TArray<FVector> Path;
+        Path.Reserve(LocalNum[t] * (TendonArcSubdivisions + 2));
         const int32 Adr = LocalAdr[t];
         const int32 Num = LocalNum[t];
-        // Mirror MuJoCo's engine_vis_visualize.c: for each consecutive wrap
-        // index pair (j, j+1), skip pulley endpoints (wrap_obj == -2), then
-        // connect wrap_xpos[3*j] -> wrap_xpos[3*j + 3].
         for (int32 j = Adr; j + 1 < Adr + Num; ++j)
         {
             if (LocalWrapObj.IsValidIndex(j)     && LocalWrapObj[j]     == -2) continue;
             if (LocalWrapObj.IsValidIndex(j + 1) && LocalWrapObj[j + 1] == -2) continue;
             if (!LocalPoints.IsValidIndex(j + 1)) continue;
+
             const FVector& A = LocalPoints[j];
             const FVector& B = LocalPoints[j + 1];
-            DrawDebugLine(World, A, B, LineColor, false, -1.0f, 0, TendonLineThickness);
+            if (Path.Num() == 0) Path.Add(A);
+
+            const int32 ObjJ  = LocalWrapObj.IsValidIndex(j)     ? LocalWrapObj[j]     : -1;
+            const int32 ObjJ1 = LocalWrapObj.IsValidIndex(j + 1) ? LocalWrapObj[j + 1] : -1;
+            if (ObjJ >= 0 && ObjJ == ObjJ1 && LocalGeomPos.IsValidIndex(ObjJ) && TendonArcSubdivisions > 0)
+            {
+                const FVector& Centre = LocalGeomPos[ObjJ];
+                const FVector VA = A - Centre;
+                const FVector VB = B - Centre;
+                for (int32 k = 1; k <= TendonArcSubdivisions; ++k)
+                {
+                    const float T = (float)k / (float)(TendonArcSubdivisions + 1);
+                    Path.Add(SlerpAboutCentre(Centre, VA, VB, T));
+                }
+            }
+            Path.Add(B);
+        }
+
+        if (Path.Num() < 2) continue;
+
+        const int32 SegCount = Path.Num() - 1;
+        TArray<FVector> Dirs;
+        TArray<float> Lens;
+        Dirs.SetNumUninitialized(SegCount);
+        Lens.SetNumUninitialized(SegCount);
+        for (int32 s = 0; s < SegCount; ++s)
+        {
+            const FVector D = Path[s + 1] - Path[s];
+            Lens[s] = D.Length();
+            Dirs[s] = Lens[s] > KINDA_SMALL_NUMBER ? (D / Lens[s]) : FVector::UpVector;
+        }
+
+        for (int32 s = 0; s < SegCount; ++s)
+        {
+            if (Lens[s] < 0.5f) continue;
+
+            const FVector StartTangent = (s > 0)
+                ? ComputeJoinTangent(Dirs[s - 1], Lens[s - 1], Dirs[s], Lens[s])
+                : Dirs[s] * Lens[s];
+            const FVector EndTangent = (s + 1 < SegCount)
+                ? ComputeJoinTangent(Dirs[s], Lens[s], Dirs[s + 1], Lens[s + 1])
+                : Dirs[s] * Lens[s];
+
+            FTubeSeg Seg;
+            Seg.Start = Path[s];
+            Seg.End = Path[s + 1];
+            Seg.StartTangent = StartTangent;
+            Seg.EndTangent = EndTangent;
+            Seg.Colour = Colour;
+            Seg.Radius = Radius;
+            Segs.Add(Seg);
+        }
+    }
+
+    while (TendonSegmentPool.Num() < Segs.Num())
+    {
+        USplineMeshComponent* New = NewObject<USplineMeshComponent>(Owner, NAME_None, RF_Transient);
+        if (!New) break;
+
+        New->SetMobility(EComponentMobility::Movable);
+        New->SetStaticMesh(TendonTubeMesh);
+        New->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+        New->SetCastShadow(false);
+        New->bSelectable = false;
+        New->bUseAttachParentBound = true;
+        New->SetForwardAxis(ESplineMeshAxis::Z);   // /Engine/BasicShapes/Cylinder extends along Z
+        New->RegisterComponent();
+        New->AttachToComponent(Owner->GetRootComponent(), FAttachmentTransformRules::KeepWorldTransform);
+
+        // Standard idiom: let the component create + own the MID so it's wired
+        // correctly through the render proxy. Creating via UMaterialInstanceDynamic::Create
+        // with the visualizer as outer resulted in the MID not routing to the mesh.
+        UMaterialInstanceDynamic* MID = New->CreateDynamicMaterialInstance(0, OverlayParentMaterial);
+
+        TendonSegmentPool.Add(New);
+        TendonSegmentMIDs.Add(MID);
+    }
+
+    for (int32 i = 0; i < TendonSegmentPool.Num(); ++i)
+    {
+        USplineMeshComponent* Seg = TendonSegmentPool[i];
+        if (!Seg) continue;
+        if (i < Segs.Num())
+        {
+            const FTubeSeg& S = Segs[i];
+            // Convert desired visible radius in cm to the scale factor applied
+            // to the base cylinder mesh (50cm radius → divide by 50).
+            const float Scale = S.Radius / kBasicCylinderBaseRadiusCm;
+            Seg->SetStartScale(FVector2D(Scale, Scale), false);
+            Seg->SetEndScale(FVector2D(Scale, Scale), false);
+            Seg->SetStartAndEnd(S.Start, S.StartTangent, S.End, S.EndTangent, true);
+            if (TendonSegmentMIDs.IsValidIndex(i) && TendonSegmentMIDs[i])
+            {
+                TendonSegmentMIDs[i]->SetVectorParameterValue(OverlayColorParam, S.Colour);
+            }
+            Seg->SetVisibility(true);
+        }
+        else
+        {
+            Seg->SetVisibility(false);
         }
     }
 }

--- a/Source/URLab/Private/MuJoCo/Utils/MjOrientationUtils.cpp
+++ b/Source/URLab/Private/MuJoCo/Utils/MjOrientationUtils.cpp
@@ -53,9 +53,13 @@ FMjCompilerSettings MjOrientationUtils::ParseCompilerSettings(const FXmlNode* Ro
 
     if (!CompilerNode) return Settings;
 
-    // angle: "degree" or "radian" (default "radian")
+    // angle: "degree" or "radian". MuJoCo's default is "degree" (Settings default).
     FString AngleStr = CompilerNode->GetAttribute(TEXT("angle"));
-    if (AngleStr.Equals(TEXT("degree"), ESearchCase::IgnoreCase))
+    if (AngleStr.Equals(TEXT("radian"), ESearchCase::IgnoreCase))
+    {
+        Settings.bAngleInDegrees = false;
+    }
+    else if (AngleStr.Equals(TEXT("degree"), ESearchCase::IgnoreCase))
     {
         Settings.bAngleInDegrees = true;
     }

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugTypes.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugTypes.h
@@ -21,4 +21,24 @@ struct FMuJoCoDebugData
      * asleep). -1 means "don't colour" (e.g. worldbody). Size nbody.
      */
     TArray<int32> BodyIslandSeed;
+
+    /**
+     * Flat array of 3D points mirroring MuJoCo's `mjData.wrap_xpos` (stride 3).
+     * MuJoCo's own renderer reads point A at offset `3*j` and point B at
+     * `3*j + 3`, where j iterates wrap-point index in `[ten_wrapadr[t],
+     * ten_wrapadr[t] + ten_wrapnum[t] - 1)`. We convert to UE coords at
+     * capture time. Logical size = 2 * nwrap (same as `nwrap x 6` layout).
+     */
+    TArray<FVector> WrapPointsFlat;
+
+    /** Mirror of `mjData.wrap_obj` (nwrap * 2 ints). -2 = pulley, skip when drawing. */
+    TArray<int32> WrapObj;
+
+    /** Per-tendon: `ten_wrapadr` / `ten_wrapnum`, length, and limit range. Sizes = ntendon. */
+    TArray<int32> TendonWrapAdr;
+    TArray<int32> TendonWrapNum;
+    TArray<float> TendonLength;
+    TArray<uint8> TendonLimited;
+    TArray<float> TendonRangeLo;
+    TArray<float> TendonRangeHi;
 };

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugTypes.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugTypes.h
@@ -41,4 +41,14 @@ struct FMuJoCoDebugData
     TArray<uint8> TendonLimited;
     TArray<float> TendonRangeLo;
     TArray<float> TendonRangeHi;
+
+    /**
+     * Per-tendon muscle activation in [0, 1] if any muscle actuator drives this
+     * tendon, else -1. Resolved by scanning actuators with trntype==TENDON.
+     * Size = ntendon.
+     */
+    TArray<float> TendonActivation;
+
+    /** Geom world positions (UE coords), size ngeom. Used to centre wrap-arc interpolation. */
+    TArray<FVector> GeomXPos;
 };

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
@@ -113,9 +113,13 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.0", ClampMax="1.0"))
     float SleepSaturationScale = 0.9f;
 
-    /** @brief Toggles tendon/muscle spline-mesh rendering. Toggled via key 7. */
+    /** @brief Toggles tendon/muscle rendering. Toggled via key 7. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug")
     bool bGlobalDrawTendons = false;
+
+    /** @brief Thickness (line width) for the debug-line tendon render style. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.5", ClampMax="20.0"))
+    float TendonLineThickness = 2.0f;
 
     // --- Thread-safe debug data ---
     FMuJoCoDebugData DebugData;
@@ -165,6 +169,9 @@ public:
 
     /** @brief Restore original materials recorded at overlay apply time, clear caches. */
     void ClearBodyOverlays();
+
+    /** @brief Draw tendons as debug lines using the latest snapshot. */
+    void DrawTendonLines();
 
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
@@ -42,6 +42,7 @@ enum class EMjDebugShaderMode : uint8
     SemanticSegmentation    UMETA(DisplayName="Semantic Segmentation (per-actor)")
 };
 
+
 /**
  * @class UMjDebugVisualizer
  * @brief Handles debug visualization for the MuJoCo simulation (contact forces, collision wireframes, etc.).
@@ -113,13 +114,17 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.0", ClampMax="1.0"))
     float SleepSaturationScale = 0.9f;
 
-    /** @brief Toggles tendon/muscle rendering. Toggled via key 7. */
+    /** @brief Toggles smooth-tube tendon/muscle rendering. Toggled via key 7. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug")
     bool bGlobalDrawTendons = false;
 
-    /** @brief Thickness (line width) for the debug-line tendon render style. */
-    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.5", ClampMax="20.0"))
-    float TendonLineThickness = 2.0f;
+    /** @brief Tube radius (cm). Muscle activation scales this up to ~2x per-tendon. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0.05", ClampMax="5.0"))
+    float TendonTubeRadius = 0.25f;
+
+    /** @brief When a tendon wraps around a cylinder/sphere geom, insert this many intermediate points along the wrap arc. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Debug", meta=(ClampMin="0", ClampMax="16"))
+    int32 TendonArcSubdivisions = 6;
 
     // --- Thread-safe debug data ---
     FMuJoCoDebugData DebugData;
@@ -170,8 +175,14 @@ public:
     /** @brief Restore original materials recorded at overlay apply time, clear caches. */
     void ClearBodyOverlays();
 
-    /** @brief Draw tendons as debug lines using the latest snapshot. */
-    void DrawTendonLines();
+    /** @brief Rebuild / reuse the spline-mesh tendon segment pool based on the latest snapshot. */
+    void UpdateTendonTubes();
+
+    /** @brief Hide the tendon tube pool without destroying it. */
+    void HideTendonTubes();
+
+    /** @brief Destroy the tube pool entirely. Used on EndPlay. */
+    void ClearTendonTubes();
 
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
@@ -186,4 +197,16 @@ private:
 
     /** Dynamic material instances we created per mesh, reused across ticks. */
     TMap<TWeakObjectPtr<class UStaticMeshComponent>, class UMaterialInstanceDynamic*> ActiveMIDs;
+
+    /** Pool of spline-mesh components used by the tube tendon render style. Grown on demand. */
+    UPROPERTY(Transient)
+    TArray<class USplineMeshComponent*> TendonSegmentPool;
+
+    /** One MID per pool entry so each tube can colour independently. Grown in lockstep with TendonSegmentPool. */
+    UPROPERTY(Transient)
+    TArray<class UMaterialInstanceDynamic*> TendonSegmentMIDs;
+
+    /** Base cylinder mesh used for every tendon segment. Loaded from /Engine/BasicShapes at BeginPlay. */
+    UPROPERTY(Transient)
+    class UStaticMesh* TendonTubeMesh = nullptr;
 };

--- a/Source/URLab/Public/MuJoCo/Utils/MjOrientationUtils.h
+++ b/Source/URLab/Public/MuJoCo/Utils/MjOrientationUtils.h
@@ -32,8 +32,14 @@ class FXmlNode;
  */
 struct FMjCompilerSettings
 {
-    /** If true, angles (euler, axisangle) are in degrees. If false (default), radians. */
-    bool bAngleInDegrees = false;
+    /**
+     * If true, angles (euler, axisangle, joint range) are in degrees.
+     * MuJoCo's upstream default when no <compiler> tag is present is "degree",
+     * so we match that. Without this default, models relying on the implicit
+     * default (e.g. tendon_arm/arm26.xml) get joint ranges like 0..120 treated
+     * as radians — the compile-time muscle lengthrange solver then diverges.
+     */
+    bool bAngleInDegrees = true;
 
     /** Euler rotation sequence, e.g. "xyz", "XYZ", "zyx". Default "xyz" (intrinsic). */
     FString EulerSeq = TEXT("xyz");

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -327,6 +327,12 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
             GeomComp->ImportFromXml(Node, CompilerSettings);
             GeomComp->bIsDefault = bIsDefaultContext;
 
+            // Preserve the MJCF 'name' so other components (tendons wrapping the
+            // geom, contact pairs referencing it) can resolve by the original
+            // name, not our auto-generated SCS variable name.
+            FString NameAttr = Node->GetAttribute(TEXT("name"));
+            if (!NameAttr.IsEmpty()) GeomComp->MjName = NameAttr;
+
             // Resolve default class transform for visual mesh placement.
             // Walk the default class hierarchy (child -> parent -> ... -> main) to find
             // the first default geom with a transform override.
@@ -695,8 +701,17 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
          }
     }
     // --- ACTUATOR ---
-    else if (Tag.Equals(TEXT("actuator")) ||
-             Tag == "motor" || Tag == "position" || Tag == "velocity" || Tag == "cylinder" || Tag == "muscle" || Tag == "general" || Tag == "damper" || Tag == "intvelocity" || Tag == "adhesion")
+    else if (Tag.Equals(TEXT("actuator")))
+    {
+         // The <actuator> container itself is just a wrapper — recurse into each
+         // per-type child (motor, muscle, position, etc.) to create components.
+         for (const FXmlNode* Child : Node->GetChildrenNodes())
+         {
+             ImportNodeRecursive(Child, ParentNode, BP, XMLDir, AssetImportPath, MeshAssets, MeshScales, TextureAssets, MaterialData, ImportedTextures, CompilerSettings, bIsDefaultContext);
+         }
+         return;
+    }
+    else if (Tag == "motor" || Tag == "position" || Tag == "velocity" || Tag == "cylinder" || Tag == "muscle" || Tag == "general" || Tag == "damper" || Tag == "intvelocity" || Tag == "adhesion")
     {
          FString Name = Node->GetAttribute(TEXT("name"));
          if (Name.IsEmpty()) Name = TEXT("AUTONAME_") + Tag;

--- a/Source/URLabEditor/Private/Tests/MjImportTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjImportTests.cpp
@@ -431,6 +431,7 @@ bool FTest_MjImport_URLab_JointRangeAndDamping::RunTest(const FString&)
     FMjXmlImportSession S;
     if (!S.Init(TEXT(R"(
         <mujoco>
+          <compiler angle="radian"/>
           <worldbody>
             <body>
               <joint name="j1" type="hinge" range="-1.57 1.57" limited="true" damping="0.5"/>

--- a/Source/URLabEditor/Private/Tests/MjMuscleTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjMuscleTests.cpp
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Round-trip tests for muscle actuators against MuJoCo's canonical 2-link
+// 6-muscle arm demo (arm26.xml from the upstream repo). A regression here
+// means our articulation export path disagrees with MuJoCo's native XML
+// parser on actuator_dyntype / gainprm / biasprm / dynprm — ie. the compiled
+// mjModel we produce would simulate differently from `mj_loadXML`.
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/MjTestHelpers.h"
+#include "MuJoCo/Components/Actuators/MjMuscleActuator.h"
+#include "MuJoCo/Components/Tendons/MjTendon.h"
+#include "MuJoCo/Components/Geometry/MjSite.h"
+#include "mujoco/mujoco.h"
+
+namespace
+{
+    // Verbatim arm26.xml (model/tendon_arm/arm26.xml) from the MuJoCo repo —
+    // 2-link arm, 6 spatial tendons, 6 muscles with a <default><muscle/> block.
+    static const TCHAR* ARM26_XML = TEXT(R"(
+        <mujoco model="2-link 6-muscle arm">
+          <option timestep="0.005" iterations="50" solver="Newton" tolerance="1e-10"/>
+          <default>
+            <joint type="hinge" pos="0 0 0" axis="0 0 1" limited="true" range="0 120" damping="0.1"/>
+            <muscle ctrllimited="true" ctrlrange="0 1"/>
+          </default>
+          <worldbody>
+            <site name="s0" pos="-0.15 0 0" size="0.02"/>
+            <site name="x0" pos="0 -0.15 0" size="0.02" rgba="0 .7 0 1" group="1"/>
+            <body pos="0 0 0">
+              <geom name="upper arm" type="capsule" size="0.045" fromto="0 0 0  0.5 0 0"/>
+              <joint name="shoulder"/>
+              <geom name="shoulder" type="cylinder" pos="0 0 0" size=".1 .05" mass="0" group="1"/>
+              <site name="s1" pos="0.15 0.06 0" size="0.02"/>
+              <site name="s2" pos="0.15 -0.06 0" size="0.02"/>
+              <site name="s3" pos="0.4 0.06 0" size="0.02"/>
+              <site name="s4" pos="0.4 -0.06 0" size="0.02"/>
+              <site name="s5" pos="0.25 0.1 0" size="0.02"/>
+              <site name="s6" pos="0.25 -0.1 0" size="0.02"/>
+              <site name="x1" pos="0.5 -0.15 0" size="0.02" rgba="0 .7 0 1" group="1"/>
+              <body pos="0.5 0 0">
+                <geom name="forearm" type="capsule" size="0.035" fromto="0 0 0  0.5 0 0"/>
+                <joint name="elbow"/>
+                <geom name="elbow" type="cylinder" pos="0 0 0" size=".08 .05" mass="0" group="1"/>
+                <site name="s7" pos="0.11 0.05 0" size="0.02"/>
+                <site name="s8" pos="0.11 -0.05 0" size="0.02"/>
+              </body>
+            </body>
+          </worldbody>
+          <tendon>
+            <spatial name="SF" width="0.01">
+              <site site="s0"/>
+              <geom geom="shoulder"/>
+              <site site="s1"/>
+            </spatial>
+            <spatial name="SE" width="0.01">
+              <site site="s0"/>
+              <geom geom="shoulder" sidesite="x0"/>
+              <site site="s2"/>
+            </spatial>
+            <spatial name="EF" width="0.01">
+              <site site="s3"/>
+              <geom geom="elbow"/>
+              <site site="s7"/>
+            </spatial>
+            <spatial name="EE" width="0.01">
+              <site site="s4"/>
+              <geom geom="elbow" sidesite="x1"/>
+              <site site="s8"/>
+            </spatial>
+            <spatial name="BF" width="0.009">
+              <site site="s0"/>
+              <geom geom="shoulder"/>
+              <site site="s5"/>
+              <geom geom="elbow"/>
+              <site site="s7"/>
+            </spatial>
+            <spatial name="BE" width="0.009">
+              <site site="s0"/>
+              <geom geom="shoulder" sidesite="x0"/>
+              <site site="s6"/>
+              <geom geom="elbow" sidesite="x1"/>
+              <site site="s8"/>
+            </spatial>
+          </tendon>
+          <actuator>
+            <muscle name="SF" tendon="SF"/>
+            <muscle name="SE" tendon="SE"/>
+            <muscle name="EF" tendon="EF"/>
+            <muscle name="EE" tendon="EE"/>
+            <muscle name="BF" tendon="BF"/>
+            <muscle name="BE" tendon="BE"/>
+          </actuator>
+        </mujoco>
+    )");
+
+    bool ActuatorParamsMatch(
+        FAutomationTestBase& Test, const TCHAR* Label,
+        const mjModel* Ref, const mjModel* Got, int32 ActuatorId)
+    {
+        const float Eps = 1e-5f;
+        bool bOk = true;
+
+        if (Ref->actuator_dyntype[ActuatorId] != Got->actuator_dyntype[ActuatorId])
+        {
+            Test.AddError(FString::Printf(
+                TEXT("%s: actuator_dyntype[%d] ref=%d got=%d"),
+                Label, ActuatorId,
+                Ref->actuator_dyntype[ActuatorId], Got->actuator_dyntype[ActuatorId]));
+            bOk = false;
+        }
+        if (Ref->actuator_gaintype[ActuatorId] != Got->actuator_gaintype[ActuatorId])
+        {
+            Test.AddError(FString::Printf(
+                TEXT("%s: actuator_gaintype[%d] ref=%d got=%d"),
+                Label, ActuatorId,
+                Ref->actuator_gaintype[ActuatorId], Got->actuator_gaintype[ActuatorId]));
+            bOk = false;
+        }
+        if (Ref->actuator_biastype[ActuatorId] != Got->actuator_biastype[ActuatorId])
+        {
+            Test.AddError(FString::Printf(
+                TEXT("%s: actuator_biastype[%d] ref=%d got=%d"),
+                Label, ActuatorId,
+                Ref->actuator_biastype[ActuatorId], Got->actuator_biastype[ActuatorId]));
+            bOk = false;
+        }
+
+        for (int p = 0; p < mjNDYN; ++p)
+        {
+            const float R = (float)Ref->actuator_dynprm[ActuatorId * mjNDYN + p];
+            const float G = (float)Got->actuator_dynprm[ActuatorId * mjNDYN + p];
+            if (FMath::Abs(R - G) > Eps)
+            {
+                Test.AddError(FString::Printf(
+                    TEXT("%s: actuator_dynprm[%d][%d] ref=%f got=%f"),
+                    Label, ActuatorId, p, R, G));
+                bOk = false;
+            }
+        }
+        for (int p = 0; p < mjNGAIN; ++p)
+        {
+            const float R = (float)Ref->actuator_gainprm[ActuatorId * mjNGAIN + p];
+            const float G = (float)Got->actuator_gainprm[ActuatorId * mjNGAIN + p];
+            if (FMath::Abs(R - G) > Eps)
+            {
+                Test.AddError(FString::Printf(
+                    TEXT("%s: actuator_gainprm[%d][%d] ref=%f got=%f"),
+                    Label, ActuatorId, p, R, G));
+                bOk = false;
+            }
+        }
+        for (int p = 0; p < mjNBIAS; ++p)
+        {
+            const float R = (float)Ref->actuator_biasprm[ActuatorId * mjNBIAS + p];
+            const float G = (float)Got->actuator_biasprm[ActuatorId * mjNBIAS + p];
+            if (FMath::Abs(R - G) > Eps)
+            {
+                Test.AddError(FString::Printf(
+                    TEXT("%s: actuator_biasprm[%d][%d] ref=%f got=%f"),
+                    Label, ActuatorId, p, R, G));
+                bOk = false;
+            }
+        }
+        return bOk;
+    }
+}
+
+// Arm26 compiles through the URLab pipeline and produces the same body /
+// tendon / actuator counts as mj_loadXML. If this fails, we've either lost
+// elements (missing import) or added duplicates.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjMuscle_Arm26_Counts,
+    "URLab.Muscle.Arm26_Counts",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FTest_MjMuscle_Arm26_Counts::RunTest(const FString&)
+{
+    FMjTestSession Ref;
+    if (!Ref.CompileXml(ARM26_XML)) { AddError(Ref.LastError); return false; }
+
+    FMjXmlImportSession S;
+    if (!S.Init(ARM26_XML))  { AddError(S.LastError); Ref.Cleanup(); return false; }
+
+    // Pre-compile diagnostic: how many component templates did the importer create?
+    AddInfo(FString::Printf(TEXT("templates: UMjMuscleActuator=%d, UMjTendon=%d, UMjSite=%d"),
+        S.CountTemplates<class UMjMuscleActuator>(),
+        S.CountTemplates<class UMjTendon>(),
+        S.CountTemplates<class UMjSite>()));
+
+    if (!S.Compile())        { AddError(S.LastError); S.Cleanup(); Ref.Cleanup(); return false; }
+
+    TestEqual(TEXT("nbody"),   (int)S.Model()->nbody,   (int)Ref.m->nbody);
+    TestEqual(TEXT("ngeom"),   (int)S.Model()->ngeom,   (int)Ref.m->ngeom);
+    TestEqual(TEXT("ntendon"), (int)S.Model()->ntendon, (int)Ref.m->ntendon);
+    TestEqual(TEXT("nu"),      (int)S.Model()->nu,      (int)Ref.m->nu);
+    TestEqual(TEXT("nsite"),   (int)S.Model()->nsite,   (int)Ref.m->nsite);
+
+    S.Cleanup();
+    Ref.Cleanup();
+    return true;
+}
+
+// For every muscle in arm26, verify dyntype / gaintype / biastype and the
+// full dynprm / gainprm / biasprm vectors match the native-parse reference
+// bit-for-bit. Catches any divergence in our mjs_setToMuscle invocation or
+// default-propagation path.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjMuscle_Arm26_ActuatorParams,
+    "URLab.Muscle.Arm26_ActuatorParams",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FTest_MjMuscle_Arm26_ActuatorParams::RunTest(const FString&)
+{
+    FMjTestSession Ref;
+    if (!Ref.CompileXml(ARM26_XML)) { AddError(Ref.LastError); return false; }
+
+    FMjXmlImportSession S;
+    if (!S.Init(ARM26_XML))  { AddError(S.LastError); Ref.Cleanup(); return false; }
+    if (!S.Compile())        { AddError(S.LastError); S.Cleanup(); Ref.Cleanup(); return false; }
+
+    if (S.Model()->nu != Ref.m->nu)
+    {
+        AddError(FString::Printf(
+            TEXT("nu mismatch before param compare: ref=%d got=%d"),
+            (int)Ref.m->nu, (int)S.Model()->nu));
+    }
+    else
+    {
+        for (int32 a = 0; a < Ref.m->nu; ++a)
+        {
+            const FString Label = FString::Printf(TEXT("arm26 actuator %d"), a);
+            ActuatorParamsMatch(*this, *Label, Ref.m, S.Model(), a);
+        }
+    }
+
+    S.Cleanup();
+    Ref.Cleanup();
+    return true;
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -77,9 +77,9 @@ See [Controller Framework](guides/controller_framework.md) for details.
 
 ## Debug Visualization
 
-Hotkey-driven toggles during PIE for contacts, collision wireframes, joint axes, and visual meshes. Per-articulation and global toggles available via MjSimulate widget.
+Hotkey-driven toggles during PIE for contact forces, collision wireframes, joint axes + limit arcs, visual-mesh visibility, constraint-island colouring, instance + semantic segmentation shaders with sleep modulation, and smooth muscle/tendon tubes with activation-driven colour and radius.
 
-See [Blueprint Reference](guides/blueprint_reference.md) for all hotkeys.
+See [Debug Visualization](guides/debug_visualization.md) for the full hotkey table and per-mode details.
 
 ## Camera System
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -90,13 +90,14 @@ All functions are `BlueprintCallable`.
 
 ## Debug Visualization
 
-See [Hotkeys](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/blueprint_reference.md#hotkeys) for keyboard shortcuts.
+See the [Debug Visualization guide](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/debug_visualization.md) for the full set of PIE overlays — contact forces, collision wireframes, joint axes, constraint islands, instance/semantic segmentation, and muscle/tendon tubes — plus the hotkeys that drive them.
 
 ## Next Steps
 
 * [features.md](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/features.md) -- complete feature reference
 * [MJCF Import](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/mujoco_import.md) -- import pipeline details
 * [Blueprint Reference](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/blueprint_reference.md) -- all Blueprint-callable functions and hotkeys
+* [Debug Visualization](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/debug_visualization.md) -- PIE overlays, segmentation, island colouring, muscle/tendon tubes
 * [ZMQ Networking](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/zmq_networking.md) -- protocol, topics, and Python examples
 * [Policy Bridge](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/policy_bridge.md) -- RL policy deployment
 * [Developer Tools](/URLab-Sim/UnrealRoboticsLab/blob/main/docs/guides/developer_tools.md) -- schema tracking, debug XML, build/test skills

--- a/docs/guides/debug_visualization.md
+++ b/docs/guides/debug_visualization.md
@@ -1,0 +1,114 @@
+# Debug Visualization
+
+Runtime overlays for inspecting the MuJoCo simulation during PIE. All toggles live on `UMjDebugVisualizer` (auto-created on `AAMjManager`) and are driven by number-row hotkeys from `UMjInputHandler`. Tune the exposed properties live from the Details panel on the Manager actor.
+
+---
+
+## Hotkeys
+
+| Key | Toggle                                            | Purpose |
+|-----|---------------------------------------------------|---------|
+| `1` | Contact force arrows                              | Yellow arrows at each active contact, scaled by normal force magnitude. |
+| `2` | Articulation visual-mesh visibility               | Hide the imported visual meshes (keeps collision/debug overlays). |
+| `3` | Articulation collision wireframes                 | Magenta wireframes of every collision geom on articulations. |
+| `4` | Joint axes + limit arcs                           | Coloured arrows at each joint showing axis direction and current/limit angle. |
+| `5` | Quick-Convert collision wireframes                | Same as `3` but for props spawned via `UMjQuickConvertComponent`. |
+| `6` | Cycle body-shader overlay                         | **Off → Island → Instance Segmentation → Semantic Segmentation → Off.** See below. |
+| `7` | Tendon/muscle smooth-tube rendering               | Spline-mesh tubes along every tendon path, thickness and colour driven by muscle activation. See below. |
+| `P` | Pause/resume the physics thread                   | |
+| `R` | Reset simulation state                            | |
+| `O` | Toggle orbit and keyframe cameras                 | |
+| `F` | Fire all `AMjImpulseLauncher` actors              | |
+
+---
+
+## Body shader overlay (key `6`)
+
+Cycles through three modes plus Off. Repaints every articulation primitive geom, every imported mesh geom, and every `UMjQuickConvertComponent` actor's static-mesh components. Original materials are cached on first apply and restored when the mode returns to Off or PIE ends.
+
+### Island
+
+Colour each body by its **constraint island** — the group of bodies mutually connected through active contacts, joint limits, equality constraints, or friction loss. Implementation mirrors MuJoCo's native visualiser (`engine_vis_visualize.c::addGeomGeoms`) exactly:
+
+- Looks up the body's first DOF via `body_weldid` → `body_dofadr`.
+- Reads `mjData.dof_island[dof]`; if ≥ 0 the body is in an active island, seed = `island_dofadr[island]`.
+- If `-1` and sleep is enabled, falls back to `tree_dofadr[dof_treeid[dof]]` (optionally passed through `mj_sleepCycle` for sleeping trees so a cluster of bodies resting on each other shares one colour).
+- Seed is fed through a Halton sequence (bases 7/3/5) to produce a HSV colour, matching upstream byte-for-byte.
+
+Bodies with no DOFs (worldbody, welded-to-world) appear neutral grey.
+
+### Instance Segmentation
+
+Each body gets a unique Halton-keyed hue mixed from the articulation class hash and the body id. Useful for generating pixel-accurate per-body segmentation masks from a `USceneCapture2D` or a `UMjCamera` — because the overlay paints real materials, it shows up in any standard render pass.
+
+### Semantic Segmentation
+
+Bodies belonging to the same articulation *class* (not instance) share a hue. Two Blueprints instanced from `BP_Humanoid` both read as one colour; a `BP_KitchenTable` reads as a different colour. For Quick-Convert props, the hue is keyed off the first static-mesh asset on the actor so props sharing a mesh group together.
+
+### Sleep modulation
+
+Independent of mode. When `bModulateBySleep` is on (default), sleeping bodies are dimmed and desaturated — `V *= SleepValueScale` (default 0.35), `S *= SleepSaturationScale` (default 0.9). Matches the upstream MuJoCo behaviour; the defaults are slightly more aggressive than upstream so the effect is clearly readable under Unreal's PBR lighting.
+
+Tune the two scales live in the Details panel if sleep needs to read even stronger (lower `SleepValueScale`) or you want fully-grey sleeping bodies (drop `SleepSaturationScale` to 0).
+
+### How it's rendered
+
+One `UMaterialInstanceDynamic` per painted mesh, parented on `/Engine/BasicShapes/BasicShapeMaterial`. At `BeginPlay` the visualiser probes that material for a vector parameter named `Color` / `BaseColor` / `Tint` and uses the first match. No plugin-shipped `.uasset` materials — stays portable across UE versions.
+
+---
+
+## Tendon / muscle rendering (key `7`)
+
+Renders every `<spatial>` / `<fixed>` tendon as a smooth tube. For muscle actuators (dyntype `mjDYN_MUSCLE` with tendon transmission), tube thickness and colour both track the muscle's activation in real time.
+
+### Visual encoding
+
+| Signal          | Visual                                                             |
+|-----------------|--------------------------------------------------------------------|
+| Muscle activation (0–1) | Radius scales from `0.5×` (relaxed) to `2.0×` (fully contracted). Colour lerps from dark blue to bright red. |
+| Limited tendon length (no muscle driver) | Same colour/radius lerp, driven by `(ten_length − range_lo) / (range_hi − range_lo)`. |
+| Neutral tendon (no muscle, no limit) | Mid-purple at nominal radius. |
+
+Per-tube colouring is real: each segment owns its own `UMaterialInstanceDynamic` (via `UPrimitiveComponent::CreateDynamicMaterialInstance`) so two muscles on the same arm read distinctly.
+
+### Path construction
+
+Each tendon's path is pulled from `mjData.wrap_xpos` / `wrap_obj` / `ten_wrapadr` / `ten_wrapnum` — this is MuJoCo's post-kinematics tendon path, including tangent points where the tendon touches a wrapping geom. The visualiser:
+
+1. Walks consecutive wrap indices exactly like MuJoCo's own renderer (`engine_vis_visualize.c::addSpatialTendonGeoms`), skipping pulley endpoints (`wrap_obj == -2`).
+2. When two consecutive wrap points share the same geom id (i.e. a cylinder or sphere wrap), subdivides the chord with `TendonArcSubdivisions` (default 6) intermediate points along a spherical interpolation about the geom's world position — so the tendon curves *around* the geom instead of jumping straight across, which is what MuJoCo's own viewer skips.
+3. Averages tangent directions at every interior wrap point, producing C1-continuous joins between segments.
+
+### How it's rendered
+
+Pool of `USplineMeshComponent`s deforming `/Engine/BasicShapes/Cylinder.Cylinder` along each segment. The cylinder ships with a 50 cm base radius, so `TendonTubeRadius` is converted to an engine scale via `scale = radius_cm / 50`. Components are created lazily, reused frame-to-frame, and hidden (not destroyed) when the tendon count drops.
+
+No physics, no collision, no shadow casting, not selectable in the viewport.
+
+### Tuning
+
+| Property                 | Default | Notes |
+|--------------------------|---------|-------|
+| `TendonTubeRadius`       | 0.25 cm | Nominal tube radius. Muscle activation scales up to 2×. |
+| `TendonArcSubdivisions`  | 6       | Intermediate points per geom-wrap arc. Drop to 0 for MuJoCo's flat chord look. |
+
+---
+
+## Camera interaction (known issue)
+
+Because the overlays swap real materials on real `UStaticMeshComponent`s, anything rendering the level — `USceneCaptureComponent2D`, `UMjCamera`, screenshot tools — captures the overlay, not the underlying scene. That's desirable for synthetic-data pipelines (Semantic Segmentation mode gives you free ground-truth masks) but unwanted if you need the RGB observation stream to stay photoreal.
+
+Workarounds today:
+- Toggle the overlay off (`6` until Off) before capturing RGB frames.
+- Script toggles around capture windows if you're generating training data.
+
+A per-camera opt-out flag is on the roadmap.
+
+---
+
+## Implementation references
+
+- Hotkey dispatch — [MjInputHandler.cpp](../../Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp)
+- Snapshot capture (physics thread) — [MjDebugVisualizer.cpp:`CaptureDebugData`](../../Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp)
+- Island Halton colour helper — [MjColor.cpp](../../Source/URLab/Private/MuJoCo/Utils/MjColor.cpp) (matches MuJoCo's upstream exactly, covered by `URLab.Color.*` automation tests)
+- Upstream reference — MuJoCo's [`engine_vis_visualize.c`](https://github.com/google-deepmind/mujoco/blob/main/src/engine/engine_vis_visualize.c)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ The plugin gives you research-grade contact dynamics alongside Unreal's renderin
 | [MJCF Import](guides/mujoco_import.md) | Importing MuJoCo XML models into Unreal |
 | [Geometry & Collision](guides/geometry_authoring.md) | Primitives, mesh geoms, Quick Convert, heightfields |
 | [Controller Framework](guides/controller_framework.md) | PD, keyframe, and custom controllers |
+| [Debug Visualization](guides/debug_visualization.md) | Hotkey-driven overlays: contacts, joints, islands, segmentation, muscle/tendon tubes |
 | [Possession & Twist Control](guides/possession_twist.md) | WASD control, spring arm camera |
 | [Scripting with Blueprints](guides/blueprint_reference.md) | Hotkeys, API usage, scripting workflows |
 | [ZMQ Networking & ROS 2](guides/zmq_networking.md) | ZMQ transport, topics, camera streaming |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - MJCF Import: guides/mujoco_import.md
     - Geometry & Collision: guides/geometry_authoring.md
     - Controller Framework: guides/controller_framework.md
+    - Debug Visualization: guides/debug_visualization.md
     - Possession & Twist Control: guides/possession_twist.md
     - Scripting with Blueprints: guides/blueprint_reference.md
     - ZMQ Networking & ROS 2: guides/zmq_networking.md


### PR DESCRIPTION
## Summary

- Fix the MJCF import pipeline so tendon/muscle models (e.g. `model/tendon_arm/arm26.xml`) compile end-to-end — previously hit `mjs_setToMuscle` crashes, missing worldbody sites, name-registration mismatches on geoms, and an incorrect radian-default for joint ranges.
- Render spatial tendons as smooth `USplineMeshComponent` tubes with activation-driven colour (dark blue → bright red) and radius (0.5× → 2× nominal). Muscle actuators drive both signals from activation; limited tendons without a muscle fall back to normalised length. Per-segment dynamic material instances so tendons on the same body read distinctly.
- Subdivide wrap arcs around cylinder/sphere geoms (`TendonArcSubdivisions`, default 6) so tendons curve around wraps instead of jumping the chord — mirrors MuJoCo's own viewer.
- Add `docs/guides/debug_visualization.md` covering every PIE overlay (contacts, joints, collision wireframes, island/segmentation shaders with sleep modulation, tendon/muscle tubes), the camera-interaction caveat, and implementation pointers. Linked from the homepage, Getting Started, Features, and mkdocs nav.

## Implementation notes

Tendon path is read from `mjData.wrap_xpos` / `wrap_obj` / `ten_wrapadr` / `ten_wrapnum` on the physics thread, then walked on the render thread skipping pulley endpoints (`wrap_obj == -2`). When two consecutive wrap points share a geom id, intermediate points are interpolated along a spherical arc about the geom's world position.

Tube rendering uses `/Engine/BasicShapes/Cylinder.Cylinder` (50 cm base radius → `scale = radius_cm / 50`) with `/Engine/BasicShapes/BasicShapeMaterial` as the parent MID — no plugin-shipped `.uasset` materials, stays portable across UE versions.

Components are created lazily, reused frame-to-frame, and hidden (not destroyed) when the tendon count drops. No physics, no collision, no shadow casting.

## Base branch
This branch is based on `feature/physics-viz-shaders` (PR #19). 