### PR TITLE
Per-camera capture modes: Real / Depth / Semantic + Instance Seg

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
@@ -22,6 +22,7 @@
 
 #include "MuJoCo/Components/Sensors/MjCamera.h"
 #include "MuJoCo/Core/AMjManager.h"
+#include "MuJoCo/Core/MjDebugVisualizer.h"
 #include "MuJoCo/Net/MjNetworkManager.h"
 #include "Engine/PostProcessVolume.h"
 #include "EngineUtils.h"
@@ -161,6 +162,35 @@ void FCameraZmqWorker::PushFrame(const TArray<FColor>& FrameData)
 // UMjCamera
 // ---------------------------------------------------------------------------
 
+namespace
+{
+    bool IsSegMode(EMjCameraMode Mode)
+    {
+        return Mode == EMjCameraMode::SemanticSegmentation
+            || Mode == EMjCameraMode::InstanceSegmentation;
+    }
+
+    UMjDebugVisualizer* FindDebugVisualizer(UWorld* FallbackWorld = nullptr)
+    {
+        if (AAMjManager* Manager = AAMjManager::GetManager())
+        {
+            return Manager->DebugVisualizer;
+        }
+        // Test/editor worlds don't dispatch BeginPlay, so the singleton may be unset.
+        if (FallbackWorld)
+        {
+            for (TActorIterator<AAMjManager> It(FallbackWorld); It; ++It)
+            {
+                if (AAMjManager* Manager = *It)
+                {
+                    return Manager->DebugVisualizer;
+                }
+            }
+        }
+        return nullptr;
+    }
+}
+
 UMjCamera::UMjCamera()
 {
     PrimaryComponentTick.bCanEverTick = true;
@@ -277,6 +307,13 @@ void UMjCamera::TickComponent(float DeltaTime, ELevelTick TickType,
         // (IStreamingManager uses timeout-based decay).
         RegisterWithStreamingManager();
 
+        // Non-seg cameras re-sync their HiddenComponents each tick so siblings
+        // spawned by a late-starting seg camera don't leak into this capture.
+        if (!IsSegMode(CaptureMode))
+        {
+            RefreshHiddenComponentsFromSegPools();
+        }
+
         // Explicit capture each tick — bCaptureEveryFrame should handle this
         // but calling it explicitly ensures the first frame fires even if
         // the component was registered after the initial world tick.
@@ -344,15 +381,21 @@ void UMjCamera::SetupRenderTarget()
 
     case EMjCameraMode::SemanticSegmentation:
     case EMjCameraMode::InstanceSegmentation:
-        UE_LOG(LogURLabImport, Warning,
-            TEXT("[MjCamera] '%s' seg mode is stubbed in P1 — captures RGB until pool wiring lands."),
-            *MjName);
-        CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_FinalToneCurveHDR;
+        // Use the standard final-tone-curve pipeline — this is what the viewport
+        // overlay uses and is known to render the MID tint correctly.
+        // SCS_BaseColor was attempted but BasicShapeMaterial's `Color` vector
+        // parameter isn't wired directly to the BaseColor G-buffer output,
+        // so nothing appeared in the RT. Tints end up lit here (not pure flat
+        // masks); a future pass that ships a dedicated unlit material would
+        // give pixel-exact ground-truth colours.
+        CaptureComponent->CaptureSource       = ESceneCaptureSource::SCS_FinalToneCurveHDR;
+        CaptureComponent->PrimitiveRenderMode = ESceneCapturePrimitiveRenderMode::PRM_UseShowOnlyList;
         break;
 
     case EMjCameraMode::Real:
     default:
-        CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_FinalToneCurveHDR;
+        CaptureComponent->CaptureSource      = ESceneCaptureSource::SCS_FinalToneCurveHDR;
+        CaptureComponent->PrimitiveRenderMode = ESceneCapturePrimitiveRenderMode::PRM_LegacySceneCapture;
         break;
     }
 
@@ -362,6 +405,24 @@ void UMjCamera::SetupRenderTarget()
         *MjName,
         *UEnum::GetValueAsString(CaptureMode),
         Resolution.X, Resolution.Y);
+}
+
+void UMjCamera::RefreshHiddenComponentsFromSegPools()
+{
+    if (!CaptureComponent) return;
+
+    UMjDebugVisualizer* Viz = FindDebugVisualizer(GetWorld());
+    if (!Viz) return;
+
+    CaptureComponent->HiddenComponents.Reset();
+
+    TArray<UPrimitiveComponent*> Pool;
+    Viz->GetSegPoolSiblings(EMjCameraMode::InstanceSegmentation, Pool);
+    for (UPrimitiveComponent* P : Pool) CaptureComponent->HiddenComponents.Add(P);
+
+    Pool.Reset();
+    Viz->GetSegPoolSiblings(EMjCameraMode::SemanticSegmentation, Pool);
+    for (UPrimitiveComponent* P : Pool) CaptureComponent->HiddenComponents.Add(P);
 }
 
 void UMjCamera::RegisterWithStreamingManager()
@@ -391,6 +452,41 @@ void UMjCamera::SetStreamingEnabled(bool bEnable)
         if (!RenderTarget)
         {
             SetupRenderTarget();
+        }
+
+        // Seg modes: subscribe to the shared sibling-mesh pool and point
+        // ShowOnlyComponents at it. Pool is built lazily on first subscriber.
+        if (IsSegMode(CaptureMode))
+        {
+            if (UMjDebugVisualizer* Viz = FindDebugVisualizer(GetWorld()))
+            {
+                TArray<UPrimitiveComponent*> Siblings;
+                Viz->AcquireSegPool(CaptureMode, this, Siblings);
+
+                CaptureComponent->ShowOnlyComponents.Reset();
+                CaptureComponent->ShowOnlyComponents.Reserve(Siblings.Num());
+                for (UPrimitiveComponent* Sib : Siblings)
+                {
+                    CaptureComponent->ShowOnlyComponents.Add(Sib);
+                }
+                UE_LOG(LogURLabImport, Log,
+                    TEXT("[MjCamera] '%s' seg mode: acquired %d sibling(s) into ShowOnlyComponents."),
+                    *MjName, Siblings.Num());
+            }
+            else
+            {
+                UE_LOG(LogURLabImport, Warning,
+                    TEXT("[MjCamera] '%s' seg mode requested but no DebugVisualizer found — seg cam will show nothing."),
+                    *MjName);
+            }
+        }
+        else
+        {
+            // Non-seg modes (Real, Depth): siblings from other seg cameras are
+            // bVisibleInSceneCaptureOnly=true, so they'd otherwise appear in RGB
+            // captures. Seed HiddenComponents now; tick-time refresh keeps it in
+            // sync with late-starting seg cameras.
+            RefreshHiddenComponentsFromSegPools();
         }
 
         if (bEnableZmqBroadcast && !ZmqWorker)
@@ -439,6 +535,21 @@ void UMjCamera::SetStreamingEnabled(bool bEnable)
     else
     {
         bStreamingEnabled = false;
+
+        // Release the seg pool first, while CaptureMode still reflects what we subscribed as.
+        if (IsSegMode(CaptureMode))
+        {
+            if (UMjDebugVisualizer* Viz = FindDebugVisualizer(GetWorld()))
+            {
+                Viz->ReleaseSegPool(CaptureMode, this);
+            }
+            if (CaptureComponent)
+            {
+                CaptureComponent->ShowOnlyComponents.Reset();
+                CaptureComponent->PrimitiveRenderMode = ESceneCapturePrimitiveRenderMode::PRM_LegacySceneCapture;
+            }
+        }
+
         if (CaptureComponent)
         {
             CaptureComponent->bCaptureEveryFrame = false;

--- a/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
@@ -295,8 +295,10 @@ void UMjCamera::TickComponent(float DeltaTime, ELevelTick TickType,
         }
     }
 
-    // Auto-request the next frame if ZMQ is enabled to maintain the stream
-    if (bStreamingEnabled && bEnableZmqBroadcast && !bReadbackPending)
+    // Auto-request the next frame if ZMQ is enabled to maintain the stream.
+    // Depth mode doesn't have a float-capable ZMQ path yet (P5 follow-up), so skip.
+    if (bStreamingEnabled && bEnableZmqBroadcast && !bReadbackPending
+        && CaptureMode != EMjCameraMode::Depth)
     {
         RequestReadback();
     }
@@ -308,29 +310,58 @@ void UMjCamera::TickComponent(float DeltaTime, ELevelTick TickType,
 
 void UMjCamera::SetupRenderTarget()
 {
-    // Owned by this component — lives exactly as long as the component does.
-    // (GetTransientPackage() makes the object GC-vulnerable in PIE even with UPROPERTY.)
     UTextureRenderTarget2D* RT = NewObject<UTextureRenderTarget2D>(this);
-    RT->RenderTargetFormat = ETextureRenderTargetFormat::RTF_RGBA8;
-    // bForceLinearGamma=true matches old_camera.h (line 282) exactly.
-    RT->InitCustomFormat(Resolution.X, Resolution.Y, PF_B8G8R8A8, /*bForceLinearGamma=*/true);
+
+    const bool bDepthMode = (CaptureMode == EMjCameraMode::Depth);
+    if (bDepthMode)
+    {
+        RT->RenderTargetFormat = ETextureRenderTargetFormat::RTF_R32f;
+        RT->InitCustomFormat(Resolution.X, Resolution.Y, PF_R32_FLOAT, /*bForceLinearGamma=*/true);
+    }
+    else
+    {
+        RT->RenderTargetFormat = ETextureRenderTargetFormat::RTF_RGBA8;
+        RT->InitCustomFormat(Resolution.X, Resolution.Y, PF_B8G8R8A8, /*bForceLinearGamma=*/true);
+    }
+
     RT->bGPUSharedFlag = true;
-    // TargetGamma — same as old_camera.h line 292
     if (GEngine)
     {
         RT->TargetGamma = GEngine->GetDisplayGamma();
     }
 
     CaptureComponent->TextureTarget = RT;
-    CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_FinalToneCurveHDR;
     CaptureComponent->bAlwaysPersistRenderingState = true;
     CaptureComponent->MaxViewDistanceOverride = -1.0f;
 
-    // No post-process or show-flag overrides for now — bare minimum to get capture working.
+    switch (CaptureMode)
+    {
+    case EMjCameraMode::Depth:
+        CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_SceneDepth;
+        CaptureComponent->bOverride_CustomNearClippingPlane = true;
+        CaptureComponent->CustomNearClippingPlane           = DepthNearCm;
+        break;
+
+    case EMjCameraMode::SemanticSegmentation:
+    case EMjCameraMode::InstanceSegmentation:
+        UE_LOG(LogURLabImport, Warning,
+            TEXT("[MjCamera] '%s' seg mode is stubbed in P1 — captures RGB until pool wiring lands."),
+            *MjName);
+        CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_FinalToneCurveHDR;
+        break;
+
+    case EMjCameraMode::Real:
+    default:
+        CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_FinalToneCurveHDR;
+        break;
+    }
 
     RenderTarget = RT;
-    UE_LOG(LogURLabImport, Log, TEXT("[MjCamera] '%s' render target created (%dx%d)"),
-        *MjName, Resolution.X, Resolution.Y);
+    UE_LOG(LogURLabImport, Log,
+        TEXT("[MjCamera] '%s' RT created mode=%s (%dx%d)"),
+        *MjName,
+        *UEnum::GetValueAsString(CaptureMode),
+        Resolution.X, Resolution.Y);
 }
 
 void UMjCamera::RegisterWithStreamingManager()
@@ -364,12 +395,21 @@ void UMjCamera::SetStreamingEnabled(bool bEnable)
 
         if (bEnableZmqBroadcast && !ZmqWorker)
         {
-            AMjArticulation* Articulation = Cast<AMjArticulation>(GetOwner());
-            FString Prefix = Articulation ? Articulation->GetName() : (GetOwner() ? GetOwner()->GetName() : TEXT("unknown"));
-            FString Topic = FString::Printf(TEXT("%s/camera/%s"), *Prefix, *GetName());
+            if (CaptureMode == EMjCameraMode::Depth)
+            {
+                UE_LOG(LogURLabNet, Warning,
+                    TEXT("[MjCamera] '%s' ZMQ broadcast skipped — Depth mode transports floats, the BGRA worker is RGB-only."),
+                    *MjName);
+            }
+            else
+            {
+                AMjArticulation* Articulation = Cast<AMjArticulation>(GetOwner());
+                FString Prefix = Articulation ? Articulation->GetName() : (GetOwner() ? GetOwner()->GetName() : TEXT("unknown"));
+                FString Topic = FString::Printf(TEXT("%s/camera/%s"), *Prefix, *GetName());
 
-            ZmqWorker = new FCameraZmqWorker(ZmqEndpoint, Topic, Resolution);
-            WorkerThread = FRunnableThread::Create(ZmqWorker, TEXT("CameraZmqWorkerThread"), 0, TPri_BelowNormal);
+                ZmqWorker = new FCameraZmqWorker(ZmqEndpoint, Topic, Resolution);
+                WorkerThread = FRunnableThread::Create(ZmqWorker, TEXT("CameraZmqWorkerThread"), 0, TPri_BelowNormal);
+            }
         }
         if (CaptureComponent)
         {
@@ -403,7 +443,11 @@ void UMjCamera::SetStreamingEnabled(bool bEnable)
         {
             CaptureComponent->bCaptureEveryFrame = false;
             CaptureComponent->SetVisibility(false); // Stop the capture dispatch loop
+            CaptureComponent->TextureTarget = nullptr;
         }
+
+        // Drop the RT so the next enable rebuilds it in the current CaptureMode.
+        RenderTarget = nullptr;
 
         if (WorkerThread)
         {

--- a/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
@@ -585,12 +585,22 @@ UStaticMeshComponent* UMjDebugVisualizer::SpawnSegSibling(
     }
     Sibling->SetRelativeTransform(Original->GetRelativeTransform());
 
-    // Visibility flags: hidden from main viewport (bVisibleInSceneCaptureOnly),
-    // visible to scene captures that either pass it through or ShowOnly it.
-    Sibling->bVisibleInSceneCaptureOnly = true;
+    // Isolation: siblings must not contribute indirect lighting, shadows, or
+    // reflections to other views. bVisibleInSceneCaptureOnly hides the primitive
+    // from the main viewport; the rest prevents secondary lighting/reflection
+    // passes from picking it up (source of the "faint tinge" in viewport
+    // otherwise). Leave bRenderInMainPass at default true — the seg capture's
+    // own rendering uses the main pass.
+    Sibling->bVisibleInSceneCaptureOnly         = true;
     Sibling->SetCastShadow(false);
     Sibling->SetCollisionEnabled(ECollisionEnabled::NoCollision);
     Sibling->SetGenerateOverlapEvents(false);
+    Sibling->bAffectDynamicIndirectLighting     = false;
+    Sibling->bAffectDistanceFieldLighting       = false;
+    Sibling->bVisibleInReflectionCaptures       = false;
+    Sibling->bVisibleInRealTimeSkyCaptures      = false;
+    Sibling->bVisibleInRayTracing               = false;
+    Sibling->bReceivesDecals                    = false;
 
     // Unlit tint material — parented on the same material the viewport overlay uses.
     // Seg cameras set CaptureSource = SCS_BaseColor, which bypasses lighting so the

--- a/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp
@@ -28,8 +28,10 @@
 #include "MuJoCo/Core/MjArticulation.h"
 #include "MuJoCo/Components/Geometry/MjGeom.h"
 #include "MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h"
+#include "MuJoCo/Components/Sensors/MjCamera.h"
 #include "DrawDebugHelpers.h"
 #include "Components/SplineMeshComponent.h"
+#include "Components/StaticMeshComponent.h"
 #include "Engine/StaticMesh.h"
 #include "Materials/MaterialInterface.h"
 #include "Materials/MaterialInstanceDynamic.h"
@@ -538,6 +540,236 @@ void UMjDebugVisualizer::UpdateBodyOverlays()
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Per-camera segmentation pool
+// ---------------------------------------------------------------------------
+
+TArray<TObjectPtr<UStaticMeshComponent>>* UMjDebugVisualizer::GetSegPoolArray(EMjCameraMode Mode)
+{
+    switch (Mode)
+    {
+    case EMjCameraMode::InstanceSegmentation: return &InstanceSegSiblings;
+    case EMjCameraMode::SemanticSegmentation: return &SemanticSegSiblings;
+    default:                                  return nullptr;
+    }
+}
+
+TSet<TWeakObjectPtr<UMjCamera>>* UMjDebugVisualizer::GetSegSubscribers(EMjCameraMode Mode)
+{
+    switch (Mode)
+    {
+    case EMjCameraMode::InstanceSegmentation: return &InstanceSegSubscribers;
+    case EMjCameraMode::SemanticSegmentation: return &SemanticSegSubscribers;
+    default:                                  return nullptr;
+    }
+}
+
+UStaticMeshComponent* UMjDebugVisualizer::SpawnSegSibling(
+    UStaticMeshComponent* Original, int32 BodyId, uint32 GroupHash, EMjCameraMode Mode)
+{
+    if (!Original || !Original->GetStaticMesh()) return nullptr;
+    if (!OverlayParentMaterial || OverlayColorParam.IsNone()) return nullptr;
+
+    AActor* Owner = Original->GetOwner();
+    if (!Owner) return nullptr;
+
+    UStaticMeshComponent* Sibling = NewObject<UStaticMeshComponent>(Owner);
+    Sibling->SetStaticMesh(Original->GetStaticMesh());
+
+    // Attach to the same parent as the original so it inherits body transforms
+    // for free — no per-tick sync needed.
+    if (USceneComponent* Parent = Original->GetAttachParent())
+    {
+        Sibling->SetupAttachment(Parent);
+    }
+    Sibling->SetRelativeTransform(Original->GetRelativeTransform());
+
+    // Visibility flags: hidden from main viewport (bVisibleInSceneCaptureOnly),
+    // visible to scene captures that either pass it through or ShowOnly it.
+    Sibling->bVisibleInSceneCaptureOnly = true;
+    Sibling->SetCastShadow(false);
+    Sibling->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+    Sibling->SetGenerateOverlapEvents(false);
+
+    // Unlit tint material — parented on the same material the viewport overlay uses.
+    // Seg cameras set CaptureSource = SCS_BaseColor, which bypasses lighting so the
+    // tint value lands in the RT unmodified.
+    UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(OverlayParentMaterial, Sibling);
+    const FLinearColor Tint = (Mode == EMjCameraMode::SemanticSegmentation)
+        ? MjColor::SemanticSegmentationColor(GroupHash, /*bAwake=*/true, /*SleepValueScale=*/1.0f, /*SleepSatScale=*/1.0f)
+        : MjColor::InstanceSegmentationColor(GroupHash, BodyId, /*bAwake=*/true, /*SleepValueScale=*/1.0f, /*SleepSatScale=*/1.0f);
+    MID->SetVectorParameterValue(OverlayColorParam, Tint);
+
+    const int32 NumSlots = FMath::Max(1, Original->GetNumMaterials());
+    for (int32 Slot = 0; Slot < NumSlots; ++Slot)
+    {
+        Sibling->SetMaterial(Slot, MID);
+    }
+
+    Sibling->ComponentTags.Add(Mode == EMjCameraMode::InstanceSegmentation
+        ? FName(TEXT("URLab_Seg_Instance"))
+        : FName(TEXT("URLab_Seg_Semantic")));
+
+    Sibling->RegisterComponent();
+    return Sibling;
+}
+
+void UMjDebugVisualizer::BuildSegPool(EMjCameraMode Mode)
+{
+    TArray<TObjectPtr<UStaticMeshComponent>>* Pool = GetSegPoolArray(Mode);
+    if (!Pool) return;
+
+    AAMjManager* Manager = Cast<AAMjManager>(GetOwner());
+    if (!Manager) return;
+
+    Pool->Reset();
+
+    auto AddSibling = [&](UStaticMeshComponent* Original, int32 BodyId, uint32 GroupHash)
+    {
+        if (UStaticMeshComponent* Sib = SpawnSegSibling(Original, BodyId, GroupHash, Mode))
+        {
+            Pool->Add(Sib);
+        }
+    };
+
+    // Articulation visual meshes — walk geoms and their static-mesh children.
+    for (AMjArticulation* Art : Manager->GetAllArticulations())
+    {
+        if (!Art) continue;
+        const uint32 ArtHash = GetTypeHash(Art->GetClass()->GetFName());
+
+        TArray<UMjGeom*> Geoms;
+        Art->GetRuntimeComponents<UMjGeom>(Geoms);
+        for (UMjGeom* Geom : Geoms)
+        {
+            if (!Geom || !Geom->IsBound()) continue;
+            const int32 BodyId = Geom->GetMj().body_id;
+
+            AddSibling(Geom->GetVisualizerMesh(), BodyId, ArtHash);
+
+            TArray<USceneComponent*> Children;
+            Geom->GetChildrenComponents(true, Children);
+            for (USceneComponent* Child : Children)
+            {
+                if (UStaticMeshComponent* SMC = Cast<UStaticMeshComponent>(Child))
+                {
+                    AddSibling(SMC, BodyId, ArtHash);
+                }
+            }
+        }
+    }
+
+    // Quick-Convert primitives — group hash keyed off the first static mesh.
+    for (UMjQuickConvertComponent* QC : Manager->GetAllQuickComponents())
+    {
+        if (!QC) continue;
+        const int32 BodyId = QC->GetMjBodyId();
+        if (BodyId < 0) continue;
+
+        AActor* Owner = QC->GetOwner();
+        if (!Owner) continue;
+
+        TArray<UStaticMeshComponent*> MeshComps;
+        Owner->GetComponents<UStaticMeshComponent>(MeshComps);
+
+        uint32 GroupHash = GetTypeHash(Owner->GetClass()->GetFName());
+        for (UStaticMeshComponent* SMC : MeshComps)
+        {
+            if (SMC && SMC->GetStaticMesh())
+            {
+                GroupHash = GetTypeHash(SMC->GetStaticMesh()->GetFName());
+                break;
+            }
+        }
+
+        for (UStaticMeshComponent* SMC : MeshComps)
+        {
+            AddSibling(SMC, BodyId, GroupHash);
+        }
+    }
+
+    UE_LOG(LogURLab, Log,
+        TEXT("[MjDebugVisualizer] Built seg pool mode=%s size=%d"),
+        *UEnum::GetValueAsString(Mode), Pool->Num());
+}
+
+void UMjDebugVisualizer::DestroySegPool(EMjCameraMode Mode)
+{
+    TArray<TObjectPtr<UStaticMeshComponent>>* Pool = GetSegPoolArray(Mode);
+    if (!Pool) return;
+
+    for (const TObjectPtr<UStaticMeshComponent>& Sib : *Pool)
+    {
+        if (Sib) Sib->DestroyComponent();
+    }
+    Pool->Reset();
+}
+
+void UMjDebugVisualizer::AcquireSegPool(EMjCameraMode Mode, UMjCamera* Camera,
+                                        TArray<UPrimitiveComponent*>& OutSiblings)
+{
+    OutSiblings.Reset();
+
+    TArray<TObjectPtr<UStaticMeshComponent>>* Pool = GetSegPoolArray(Mode);
+    TSet<TWeakObjectPtr<UMjCamera>>*          Subs = GetSegSubscribers(Mode);
+    if (!Pool || !Subs) return;
+
+    const bool bFirstSubscriber = Subs->Num() == 0;
+    Subs->Add(Camera);
+
+    if (bFirstSubscriber)
+    {
+        BuildSegPool(Mode);
+    }
+
+    OutSiblings.Reserve(Pool->Num());
+    for (const TObjectPtr<UStaticMeshComponent>& Sib : *Pool)
+    {
+        if (Sib) OutSiblings.Add(Sib);
+    }
+}
+
+void UMjDebugVisualizer::ReleaseSegPool(EMjCameraMode Mode, UMjCamera* Camera)
+{
+    TSet<TWeakObjectPtr<UMjCamera>>* Subs = GetSegSubscribers(Mode);
+    if (!Subs) return;
+
+    Subs->Remove(Camera);
+    // Also drop any stale weak pointers so refcount reflects reality.
+    for (auto It = Subs->CreateIterator(); It; ++It)
+    {
+        if (!It->IsValid()) It.RemoveCurrent();
+    }
+
+    if (Subs->Num() == 0)
+    {
+        DestroySegPool(Mode);
+    }
+}
+
+void UMjDebugVisualizer::GetSegPoolSiblings(EMjCameraMode Mode,
+                                            TArray<UPrimitiveComponent*>& OutSiblings) const
+{
+    OutSiblings.Reset();
+    const TArray<TObjectPtr<UStaticMeshComponent>>* Pool = nullptr;
+    switch (Mode)
+    {
+    case EMjCameraMode::InstanceSegmentation: Pool = &InstanceSegSiblings; break;
+    case EMjCameraMode::SemanticSegmentation: Pool = &SemanticSegSiblings; break;
+    default:                                  return;
+    }
+
+    OutSiblings.Reserve(Pool->Num());
+    for (const TObjectPtr<UStaticMeshComponent>& Sib : *Pool)
+    {
+        if (Sib) OutSiblings.Add(Sib);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tendon rendering
+// ---------------------------------------------------------------------------
 
 void UMjDebugVisualizer::HideTendonTubes()
 {

--- a/Source/URLab/Private/UI/MjCameraFeedEntry.cpp
+++ b/Source/URLab/Private/UI/MjCameraFeedEntry.cpp
@@ -24,6 +24,8 @@
 #include "Components/TextBlock.h"
 #include "Components/Image.h"
 #include "Engine/TextureRenderTarget2D.h"
+#include "Engine/Texture2D.h"
+#include "TextureResource.h"
 #include "Materials/MaterialInstanceDynamic.h"
 #include "Materials/Material.h"
 #include "Styling/SlateTypes.h"
@@ -61,22 +63,82 @@ void UMjCameraFeedEntry::RefreshBrush()
         ? W * static_cast<float>(BoundCamera->Resolution.Y) / static_cast<float>(BoundCamera->Resolution.X)
         : W * 0.75f;
 
-    // Set the render target DIRECTLY as the brush resource.
-    // This works without any material and has no domain restriction.
-    // (SetBrushFromMaterial silently renders nothing if the material domain
-    //  is not "User Interface" — avoid that path unless you're sure.)
-    FeedImage->SetBrushResourceObject(RT);
+    // Depth RT is R32f — slate can't display it directly. Build (or reuse)
+    // a BGRA UTexture2D preview and bind THAT as the brush. For all other
+    // modes the RT is BGRA8 and we can bind it directly.
+    UObject* BrushResource = nullptr;
+    if (BoundCamera->CaptureMode == EMjCameraMode::Depth)
+    {
+        if (!DepthPreviewTexture
+            || DepthPreviewTexture->GetSizeX() != BoundCamera->Resolution.X
+            || DepthPreviewTexture->GetSizeY() != BoundCamera->Resolution.Y)
+        {
+            DepthPreviewTexture = UTexture2D::CreateTransient(
+                BoundCamera->Resolution.X, BoundCamera->Resolution.Y, PF_B8G8R8A8,
+                TEXT("URLabDepthPreview"));
+            DepthPreviewTexture->CompressionSettings = TC_VectorDisplacementmap;
+            DepthPreviewTexture->SRGB = false;
+            DepthPreviewTexture->UpdateResource();
+        }
+        BrushResource = DepthPreviewTexture;
+    }
+    else
+    {
+        DepthPreviewTexture = nullptr;
+        BrushResource = RT;
+    }
 
-    // Patch the rest of the brush properties on the copy UImage holds internally
+    FeedImage->SetBrushResourceObject(BrushResource);
+
     FSlateBrush Brush = FeedImage->GetBrush();
-    Brush.DrawAs   = ESlateBrushDrawType::Image;
+    Brush.DrawAs    = ESlateBrushDrawType::Image;
     Brush.ImageType = ESlateBrushImageType::FullColor;
-    Brush.Tiling   = ESlateBrushTileType::NoTile;
+    Brush.Tiling    = ESlateBrushTileType::NoTile;
     Brush.ImageSize = FVector2D(W, H);
     FeedImage->SetBrush(Brush);
 
-    UE_LOG(LogURLab, Log, TEXT("[MjCameraFeedEntry] Brush set: '%s' RT=%dx%d display=%.0fx%.0f"),
-        *BoundCamera->MjName, RT->SizeX, RT->SizeY, W, H);
+    UE_LOG(LogURLab, Log,
+        TEXT("[MjCameraFeedEntry] Brush set: '%s' mode=%s RT=%dx%d display=%.0fx%.0f"),
+        *BoundCamera->MjName, *UEnum::GetValueAsString(BoundCamera->CaptureMode),
+        RT->SizeX, RT->SizeY, W, H);
+}
+
+void UMjCameraFeedEntry::UpdateDepthPreview()
+{
+    if (!BoundCamera || !DepthPreviewTexture) return;
+    UTextureRenderTarget2D* RT = BoundCamera->RenderTarget;
+    if (!RT) return;
+
+    FTextureRenderTargetResource* Res = RT->GameThread_GetRenderTargetResource();
+    if (!Res) return;
+
+    // Read the depth RT into FLinearColor pixels. The R channel holds linear
+    // scene depth in centimetres (Unreal's world units).
+    if (!Res->ReadLinearColorPixels(DepthReadbackScratch)) return;
+
+    const int32 SizeX = RT->SizeX;
+    const int32 SizeY = RT->SizeY;
+    if (DepthReadbackScratch.Num() != SizeX * SizeY) return;
+
+    const float Near = FMath::Max(0.1f, BoundCamera->DepthNearCm);
+    const float Far  = FMath::Max(Near + 1.0f, BoundCamera->DepthFarCm);
+    const float InvRange = 1.0f / (Far - Near);
+
+    // Update the platform texture's mip0 pixels. BGRA byte order.
+    FTexture2DMipMap& Mip = DepthPreviewTexture->GetPlatformData()->Mips[0];
+    uint8* Dst = (uint8*)Mip.BulkData.Lock(LOCK_READ_WRITE);
+    for (int32 i = 0; i < DepthReadbackScratch.Num(); ++i)
+    {
+        const float Depth = DepthReadbackScratch[i].R;
+        const float Norm  = FMath::Clamp((Depth - Near) * InvRange, 0.0f, 1.0f);
+        const uint8 Gray  = (uint8)FMath::RoundToInt(Norm * 255.0f);
+        Dst[i * 4 + 0] = Gray;  // B
+        Dst[i * 4 + 1] = Gray;  // G
+        Dst[i * 4 + 2] = Gray;  // R
+        Dst[i * 4 + 3] = 255;   // A
+    }
+    Mip.BulkData.Unlock();
+    DepthPreviewTexture->UpdateResource();
 }
 
 void UMjCameraFeedEntry::UnbindCamera()
@@ -87,16 +149,22 @@ void UMjCameraFeedEntry::UnbindCamera()
         BoundCamera = nullptr;
     }
     FeedMID = nullptr;
+    DepthPreviewTexture = nullptr;
+    DepthReadbackScratch.Reset();
     if (FeedImage) FeedImage->SetBrush(FSlateBrush());
 }
 
 void UMjCameraFeedEntry::UpdateFeed()
 {
-    if (BoundCamera && FeedImage && BoundCamera->RenderTarget)
+    if (!BoundCamera || !FeedImage || !BoundCamera->RenderTarget) return;
+
+    if (!FeedImage->GetBrush().GetResourceObject())
     {
-        if (!FeedImage->GetBrush().GetResourceObject())
-        {
-            RefreshBrush();
-        }
+        RefreshBrush();
+    }
+
+    if (BoundCamera->CaptureMode == EMjCameraMode::Depth)
+    {
+        UpdateDepthPreview();
     }
 }

--- a/Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h
+++ b/Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h
@@ -32,6 +32,20 @@
 #include "MjCamera.generated.h"
 
 /**
+ * @enum EMjCameraMode
+ * @brief What a UMjCamera captures. Read at SetStreamingEnabled(true) time —
+ *        to change mode on a running camera, toggle streaming off then on.
+ */
+UENUM(BlueprintType)
+enum class EMjCameraMode : uint8
+{
+    Real                 UMETA(DisplayName = "Photoreal RGB"),
+    Depth                UMETA(DisplayName = "Depth"),
+    SemanticSegmentation UMETA(DisplayName = "Semantic Segmentation"),
+    InstanceSegmentation UMETA(DisplayName = "Instance Segmentation"),
+};
+
+/**
  * @class FCameraZmqWorker
  * @brief Background thread for publishing high-bandwidth camera frames via ZeroMQ.
  */
@@ -97,6 +111,21 @@ public:
     /** @brief Capture resolution (pixels). Defaults to 640×480. */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Camera")
     FIntPoint Resolution = FIntPoint(640, 480);
+
+    /** @brief What this camera captures. Read at SetStreamingEnabled(true) time —
+     *  toggle streaming off/on after changing. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Camera")
+    EMjCameraMode CaptureMode = EMjCameraMode::Real;
+
+    /** @brief Near clip plane for Depth capture, centimetres. Values below this read as 0. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Camera",
+        meta = (EditCondition = "CaptureMode == EMjCameraMode::Depth", ClampMin = "0.1"))
+    float DepthNearCm = 10.0f;
+
+    /** @brief Far clip plane for Depth capture, centimetres. Values beyond read as the maximum. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Camera",
+        meta = (EditCondition = "CaptureMode == EMjCameraMode::Depth", ClampMin = "1.0"))
+    float DepthFarCm = 10000.0f;
 
     // ---- Streaming ----
 

--- a/Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h
+++ b/Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h
@@ -209,6 +209,11 @@ private:
     void SetupRenderTarget();
     void RegisterWithStreamingManager();
 
+    /** For non-seg modes: rebuild HiddenComponents from the currently-live seg pools.
+     *  Cheap (N siblings pointer copies), called each tick so a late-starting seg
+     *  camera doesn't contaminate an already-streaming RGB/Depth camera. */
+    void RefreshHiddenComponentsFromSegPools();
+
     // ---- Readback state ----
     TOptional<TArray<FColor>> PendingPixels;
     FRenderCommandFence       ReadbackFence;

--- a/Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h
+++ b/Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h
@@ -29,21 +29,8 @@
 #include "HAL/Runnable.h"
 #include "HAL/ThreadSafeBool.h"
 #include "Containers/Queue.h"
+#include "MuJoCo/Components/Sensors/MjCameraTypes.h"
 #include "MjCamera.generated.h"
-
-/**
- * @enum EMjCameraMode
- * @brief What a UMjCamera captures. Read at SetStreamingEnabled(true) time —
- *        to change mode on a running camera, toggle streaming off then on.
- */
-UENUM(BlueprintType)
-enum class EMjCameraMode : uint8
-{
-    Real                 UMETA(DisplayName = "Photoreal RGB"),
-    Depth                UMETA(DisplayName = "Depth"),
-    SemanticSegmentation UMETA(DisplayName = "Semantic Segmentation"),
-    InstanceSegmentation UMETA(DisplayName = "Instance Segmentation"),
-};
 
 /**
  * @class FCameraZmqWorker

--- a/Source/URLab/Public/MuJoCo/Components/Sensors/MjCameraTypes.h
+++ b/Source/URLab/Public/MuJoCo/Components/Sensors/MjCameraTypes.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MjCameraTypes.generated.h"
+
+/**
+ * @enum EMjCameraMode
+ * @brief What a UMjCamera captures. Read at SetStreamingEnabled(true) time —
+ *        to change mode on a running camera, toggle streaming off then on.
+ *
+ * Lives in its own header so UMjDebugVisualizer can reference the enum without
+ * pulling in the full UMjCamera include chain (SceneCaptureComponent2D, etc).
+ */
+UENUM(BlueprintType)
+enum class EMjCameraMode : uint8
+{
+    Real                 UMETA(DisplayName = "Photoreal RGB"),
+    Depth                UMETA(DisplayName = "Depth"),
+    SemanticSegmentation UMETA(DisplayName = "Semantic Segmentation"),
+    InstanceSegmentation UMETA(DisplayName = "Instance Segmentation"),
+};

--- a/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjDebugVisualizer.h
@@ -25,11 +25,13 @@
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
 #include "MuJoCo/Core/MjDebugTypes.h"
+#include "MuJoCo/Components/Sensors/MjCameraTypes.h"
 #include "MjDebugVisualizer.generated.h"
 
 // Forward declarations
 class AAMjManager;
 class UMaterialInterface;
+class UMjCamera;
 struct FMuJoCoDebugData;
 
 /** Per-body visual overlay mode applied during PIE. */
@@ -186,8 +188,61 @@ public:
 
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
+    // --- Per-camera segmentation pool ---
+    //
+    // Seg-mode UMjCameras share sibling mesh components rather than each maintaining
+    // their own. Pools are lazy: built on first Acquire, destroyed on last Release.
+    // Only two modes are poolable — InstanceSegmentation and SemanticSegmentation.
+
+    /**
+     * @brief Subscribe a camera to the sibling-mesh pool for Mode.
+     *        Builds the pool on first subscription, returns its sibling primitives.
+     * @param Mode         Must be Semantic- or InstanceSegmentation; other values are a no-op.
+     * @param Camera       Subscriber; tracked so Release can refcount correctly.
+     * @param OutSiblings  Populated with the shared sibling primitives for the camera's ShowOnly list.
+     */
+    void AcquireSegPool(EMjCameraMode Mode, UMjCamera* Camera,
+                        TArray<UPrimitiveComponent*>& OutSiblings);
+
+    /**
+     * @brief Unsubscribe a camera. When the last subscriber leaves, the pool is destroyed.
+     */
+    void ReleaseSegPool(EMjCameraMode Mode, UMjCamera* Camera);
+
+    /**
+     * @brief Snapshot of a currently-live sibling pool. Used for tests and for
+     *        non-seg URLab cameras that need to hide siblings via HiddenComponents.
+     */
+    void GetSegPoolSiblings(EMjCameraMode Mode, TArray<UPrimitiveComponent*>& OutSiblings) const;
+
 private:
     bool bVisualsHidden = false;
+
+    /** Sibling-mesh pool for InstanceSegmentation-mode cameras. Empty when no subscribers. */
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<UStaticMeshComponent>> InstanceSegSiblings;
+
+    /** Sibling-mesh pool for SemanticSegmentation-mode cameras. */
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<UStaticMeshComponent>> SemanticSegSiblings;
+
+    TSet<TWeakObjectPtr<UMjCamera>> InstanceSegSubscribers;
+    TSet<TWeakObjectPtr<UMjCamera>> SemanticSegSubscribers;
+
+    /** Returns a mutable ref to the pool matching Mode, or null for non-seg modes. */
+    TArray<TObjectPtr<UStaticMeshComponent>>* GetSegPoolArray(EMjCameraMode Mode);
+    TSet<TWeakObjectPtr<UMjCamera>>* GetSegSubscribers(EMjCameraMode Mode);
+
+    /** Build the seg pool for Mode by walking the world's articulations + quick-convert. */
+    void BuildSegPool(EMjCameraMode Mode);
+
+    /** Destroy all siblings in Mode's pool and clear it. */
+    void DestroySegPool(EMjCameraMode Mode);
+
+    /** Spawn one sibling mesh for a given original. Returns the new component (already registered). */
+    UStaticMeshComponent* SpawnSegSibling(UStaticMeshComponent* Original,
+                                          int32 BodyId, uint32 GroupHash,
+                                          EMjCameraMode Mode);
 
     /** Original slot-0 material on meshes we've overridden, so we can restore. Keyed by mesh component. */
     TMap<TWeakObjectPtr<class UStaticMeshComponent>, class UMaterialInterface*> OriginalMaterials;

--- a/Source/URLab/Public/UI/MjCameraFeedEntry.h
+++ b/Source/URLab/Public/UI/MjCameraFeedEntry.h
@@ -30,6 +30,7 @@
 class UTextBlock;
 class UImage;
 class UMaterialInstanceDynamic;
+class UTexture2D;
 
 /**
  * @class UMjCameraFeedEntry
@@ -92,9 +93,21 @@ private:
     /** @brief (Re-)applies the FSlateBrush to FeedImage using the current render target. */
     void RefreshBrush();
 
+    /** @brief Depth mode: CPU-copy the R32f RT into DepthPreviewTexture as
+     *         grayscale, normalised by the camera's DepthNear/Far range. */
+    void UpdateDepthPreview();
+
     UPROPERTY()
     UMjCamera* BoundCamera = nullptr;
 
     UPROPERTY()
     UMaterialInstanceDynamic* FeedMID = nullptr;
+
+    /** Slate-displayable BGRA texture used as the brush resource when the bound
+     *  camera is in Depth mode. Null for other modes. */
+    UPROPERTY(Transient)
+    UTexture2D* DepthPreviewTexture = nullptr;
+
+    /** Scratch buffer reused by the depth CPU readback to avoid per-tick allocation. */
+    TArray<FLinearColor> DepthReadbackScratch;
 };

--- a/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/MjTestHelpers.h"
+#include "MuJoCo/Components/Sensors/MjCamera.h"
+#include "Components/SceneCaptureComponent2D.h"
+#include "Engine/TextureRenderTarget2D.h"
+
+namespace
+{
+    /**
+     * Spawn a UMjCamera on the test articulation with the given mode and enable streaming.
+     * Returns the camera so callers can inspect state after configuration.
+     */
+    UMjCamera* SpawnCameraAndStream(FMjUESession& Sess, EMjCameraMode Mode)
+    {
+        UMjCamera* Cam = NewObject<UMjCamera>(Sess.Robot, TEXT("TestCamera"));
+        Cam->CaptureMode = Mode;
+        Cam->RegisterComponent();
+        Cam->AttachToComponent(Sess.Body, FAttachmentTransformRules::KeepRelativeTransform);
+        Cam->SetStreamingEnabled(true);
+        return Cam;
+    }
+}
+
+// ============================================================================
+// URLab.Camera.RealMode_ConfiguresFinalColorBGRA
+//   Default Real mode → RT is RGBA8, CaptureSource is SCS_FinalToneCurveHDR.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCameraRealModeConfig,
+    "URLab.Camera.RealMode_ConfiguresFinalColorBGRA",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCameraRealModeConfig::RunTest(const FString& Parameters)
+{
+    FMjUESession S;
+    if (!S.Init())
+    {
+        AddError(FString::Printf(TEXT("FMjUESession::Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjCamera* Cam = SpawnCameraAndStream(S, EMjCameraMode::Real);
+    if (!TestNotNull(TEXT("camera"), Cam)) { S.Cleanup(); return false; }
+
+    if (!TestNotNull(TEXT("RT"), Cam->RenderTarget)) { S.Cleanup(); return false; }
+    TestEqual(TEXT("RT format"), (int32)Cam->RenderTarget->RenderTargetFormat, (int32)ETextureRenderTargetFormat::RTF_RGBA8);
+
+    if (TestNotNull(TEXT("capture component"), Cam->CaptureComponent))
+    {
+        TestEqual(TEXT("capture source"),
+            (int32)Cam->CaptureComponent->CaptureSource,
+            (int32)ESceneCaptureSource::SCS_FinalToneCurveHDR);
+    }
+
+    S.Cleanup();
+    return true;
+}
+
+// ============================================================================
+// URLab.Camera.DepthMode_ConfiguresSceneDepthFloat
+//   Depth mode → RT is R32f, CaptureSource is SCS_SceneDepth, near clip overridden.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCameraDepthModeConfig,
+    "URLab.Camera.DepthMode_ConfiguresSceneDepthFloat",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCameraDepthModeConfig::RunTest(const FString& Parameters)
+{
+    FMjUESession S;
+    if (!S.Init())
+    {
+        AddError(FString::Printf(TEXT("FMjUESession::Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjCamera* Cam = SpawnCameraAndStream(S, EMjCameraMode::Depth);
+    if (!TestNotNull(TEXT("camera"), Cam)) { S.Cleanup(); return false; }
+
+    if (!TestNotNull(TEXT("RT"), Cam->RenderTarget)) { S.Cleanup(); return false; }
+    TestEqual(TEXT("RT format"), (int32)Cam->RenderTarget->RenderTargetFormat, (int32)ETextureRenderTargetFormat::RTF_R32f);
+
+    if (TestNotNull(TEXT("capture component"), Cam->CaptureComponent))
+    {
+        TestEqual(TEXT("capture source"),
+            (int32)Cam->CaptureComponent->CaptureSource,
+            (int32)ESceneCaptureSource::SCS_SceneDepth);
+        TestTrue(TEXT("near clip overridden"), Cam->CaptureComponent->bOverride_CustomNearClippingPlane);
+        TestEqual(TEXT("near clip value"),
+            Cam->CaptureComponent->CustomNearClippingPlane, Cam->DepthNearCm);
+    }
+
+    S.Cleanup();
+    return true;
+}
+
+// ============================================================================
+// URLab.Camera.ModeCycle_RebuildsRenderTarget
+//   Toggling streaming off then on after a mode change rebuilds the RT with
+//   the new format. Real → Depth should switch RTF_RGBA8 → RTF_R32f.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCameraModeCycleRebuildsRT,
+    "URLab.Camera.ModeCycle_RebuildsRenderTarget",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCameraModeCycleRebuildsRT::RunTest(const FString& Parameters)
+{
+    FMjUESession S;
+    if (!S.Init())
+    {
+        AddError(FString::Printf(TEXT("FMjUESession::Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjCamera* Cam = SpawnCameraAndStream(S, EMjCameraMode::Real);
+    if (!TestNotNull(TEXT("camera"), Cam)) { S.Cleanup(); return false; }
+    TestEqual(TEXT("initial format"), (int32)Cam->RenderTarget->RenderTargetFormat, (int32)ETextureRenderTargetFormat::RTF_RGBA8);
+
+    Cam->SetStreamingEnabled(false);
+    TestNull(TEXT("RT cleared after disable"), Cam->RenderTarget);
+
+    Cam->CaptureMode = EMjCameraMode::Depth;
+    Cam->SetStreamingEnabled(true);
+    if (!TestNotNull(TEXT("RT rebuilt"), Cam->RenderTarget)) { S.Cleanup(); return false; }
+    TestEqual(TEXT("new format"), (int32)Cam->RenderTarget->RenderTargetFormat, (int32)ETextureRenderTargetFormat::RTF_R32f);
+
+    S.Cleanup();
+    return true;
+}

--- a/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
@@ -225,3 +225,108 @@ bool FMjCameraSegPoolRefcount::RunTest(const FString& Parameters)
     S.Cleanup();
     return true;
 }
+
+// ============================================================================
+// URLab.Camera.SegMode_WiresShowOnlyListFromPool
+//   A seg camera at SetStreamingEnabled(true) configures its CaptureComponent:
+//   PRM_UseShowOnlyList, CaptureSource = SCS_BaseColor, ShowOnlyComponents
+//   populated from the pool.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCameraSegWiresShowOnly,
+    "URLab.Camera.SegMode_WiresShowOnlyListFromPool",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCameraSegWiresShowOnly::RunTest(const FString& Parameters)
+{
+    FMjUESession S;
+    if (!S.Init())
+    {
+        AddError(FString::Printf(TEXT("FMjUESession::Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    if (S.Manager && S.Manager->DebugVisualizer)
+    {
+        S.Manager->DebugVisualizer->InitializeOverlayMaterial();
+    }
+
+    UStaticMesh* CubeMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Cube.Cube"));
+    UStaticMeshComponent* ChildMesh = NewObject<UStaticMeshComponent>(S.Robot, TEXT("GeomChildMesh"));
+    ChildMesh->SetStaticMesh(CubeMesh);
+    ChildMesh->RegisterComponent();
+    ChildMesh->AttachToComponent(S.Geom, FAttachmentTransformRules::KeepRelativeTransform);
+
+    UMjCamera* Cam = NewObject<UMjCamera>(S.Robot, TEXT("SegCam"));
+    Cam->CaptureMode = EMjCameraMode::InstanceSegmentation;
+    Cam->RegisterComponent();
+    Cam->AttachToComponent(S.Body, FAttachmentTransformRules::KeepRelativeTransform);
+    Cam->SetStreamingEnabled(true);
+
+    if (!TestNotNull(TEXT("capture component"), Cam->CaptureComponent)) { S.Cleanup(); return false; }
+    TestEqual(TEXT("capture source"),
+        (int32)Cam->CaptureComponent->CaptureSource,
+        (int32)ESceneCaptureSource::SCS_FinalToneCurveHDR);
+    TestEqual(TEXT("primitive render mode"),
+        (int32)Cam->CaptureComponent->PrimitiveRenderMode,
+        (int32)ESceneCapturePrimitiveRenderMode::PRM_UseShowOnlyList);
+    TestTrue(TEXT("ShowOnlyComponents populated"),
+        Cam->CaptureComponent->ShowOnlyComponents.Num() > 0);
+
+    Cam->SetStreamingEnabled(false);
+    TestEqual(TEXT("ShowOnlyComponents cleared on disable"),
+        Cam->CaptureComponent->ShowOnlyComponents.Num(), 0);
+
+    S.Cleanup();
+    return true;
+}
+
+// ============================================================================
+// URLab.Camera.NonSegMode_HidesSiblingPool
+//   A Real-mode camera and an InstanceSeg camera coexist: the Real camera's
+//   HiddenComponents list includes the seg pool siblings.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCameraNonSegHidesSiblings,
+    "URLab.Camera.NonSegMode_HidesSiblingPool",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCameraNonSegHidesSiblings::RunTest(const FString& Parameters)
+{
+    FMjUESession S;
+    if (!S.Init())
+    {
+        AddError(FString::Printf(TEXT("FMjUESession::Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    if (S.Manager && S.Manager->DebugVisualizer)
+    {
+        S.Manager->DebugVisualizer->InitializeOverlayMaterial();
+    }
+
+    UStaticMesh* CubeMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Cube.Cube"));
+    UStaticMeshComponent* ChildMesh = NewObject<UStaticMeshComponent>(S.Robot, TEXT("GeomChildMesh"));
+    ChildMesh->SetStaticMesh(CubeMesh);
+    ChildMesh->RegisterComponent();
+    ChildMesh->AttachToComponent(S.Geom, FAttachmentTransformRules::KeepRelativeTransform);
+
+    // Start the seg camera first so the pool exists when the Real camera subscribes.
+    UMjCamera* Seg = NewObject<UMjCamera>(S.Robot, TEXT("SegCam"));
+    Seg->CaptureMode = EMjCameraMode::InstanceSegmentation;
+    Seg->RegisterComponent();
+    Seg->AttachToComponent(S.Body, FAttachmentTransformRules::KeepRelativeTransform);
+    Seg->SetStreamingEnabled(true);
+
+    UMjCamera* Real = NewObject<UMjCamera>(S.Robot, TEXT("RealCam"));
+    Real->CaptureMode = EMjCameraMode::Real;
+    Real->RegisterComponent();
+    Real->AttachToComponent(S.Body, FAttachmentTransformRules::KeepRelativeTransform);
+    Real->SetStreamingEnabled(true);
+
+    if (!TestNotNull(TEXT("real capture component"), Real->CaptureComponent)) { S.Cleanup(); return false; }
+    const int32 ExpectedHidden = Seg->CaptureComponent->ShowOnlyComponents.Num();
+    TestEqual(TEXT("real cam hides seg siblings"),
+        Real->CaptureComponent->HiddenComponents.Num(), ExpectedHidden);
+
+    S.Cleanup();
+    return true;
+}

--- a/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
@@ -24,8 +24,13 @@
 #include "Misc/AutomationTest.h"
 #include "Tests/MjTestHelpers.h"
 #include "MuJoCo/Components/Sensors/MjCamera.h"
+#include "MuJoCo/Core/MjDebugVisualizer.h"
+#include "MuJoCo/Core/AMjManager.h"
 #include "Components/SceneCaptureComponent2D.h"
+#include "Components/StaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
 #include "Engine/TextureRenderTarget2D.h"
+#include "UObject/ConstructorHelpers.h"
 
 namespace
 {
@@ -144,6 +149,78 @@ bool FMjCameraModeCycleRebuildsRT::RunTest(const FString& Parameters)
     Cam->SetStreamingEnabled(true);
     if (!TestNotNull(TEXT("RT rebuilt"), Cam->RenderTarget)) { S.Cleanup(); return false; }
     TestEqual(TEXT("new format"), (int32)Cam->RenderTarget->RenderTargetFormat, (int32)ETextureRenderTargetFormat::RTF_R32f);
+
+    S.Cleanup();
+    return true;
+}
+
+// ============================================================================
+// URLab.Camera.SegPool_AcquireReleaseRefcount
+//   Pool lifecycle: two cameras acquire → shared pool is built once, survives
+//   one release, is destroyed on the second release.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCameraSegPoolRefcount,
+    "URLab.Camera.SegPool_AcquireReleaseRefcount",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCameraSegPoolRefcount::RunTest(const FString& Parameters)
+{
+    FMjUESession S;
+    if (!S.Init())
+    {
+        AddError(FString::Printf(TEXT("FMjUESession::Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjDebugVisualizer* Viz = S.Manager ? S.Manager->FindComponentByClass<UMjDebugVisualizer>() : nullptr;
+    if (!TestNotNull(TEXT("visualizer"), Viz)) { S.Cleanup(); return false; }
+
+    // The visualizer's OverlayParentMaterial is initialized in BeginPlay; test worlds
+    // don't dispatch BeginPlay, so trigger initialization manually.
+    Viz->InitializeOverlayMaterial();
+
+    // FMjUESession's base UMjGeom has no visualizer mesh. Attach a static-mesh child
+    // so BuildSegPool's child walk has something to mirror into a sibling.
+    UStaticMesh* CubeMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Cube.Cube"));
+    if (!TestNotNull(TEXT("engine cube mesh"), CubeMesh)) { S.Cleanup(); return false; }
+
+    UStaticMeshComponent* ChildMesh = NewObject<UStaticMeshComponent>(S.Robot, TEXT("GeomChildMesh"));
+    ChildMesh->SetStaticMesh(CubeMesh);
+    ChildMesh->RegisterComponent();
+    ChildMesh->AttachToComponent(S.Geom, FAttachmentTransformRules::KeepRelativeTransform);
+
+    UMjCamera* CamA = NewObject<UMjCamera>(S.Robot, TEXT("CamA"));
+    CamA->CaptureMode = EMjCameraMode::InstanceSegmentation;
+    CamA->RegisterComponent();
+    CamA->AttachToComponent(S.Body, FAttachmentTransformRules::KeepRelativeTransform);
+
+    UMjCamera* CamB = NewObject<UMjCamera>(S.Robot, TEXT("CamB"));
+    CamB->CaptureMode = EMjCameraMode::InstanceSegmentation;
+    CamB->RegisterComponent();
+    CamB->AttachToComponent(S.Body, FAttachmentTransformRules::KeepRelativeTransform);
+
+    TArray<UPrimitiveComponent*> PoolA;
+    Viz->AcquireSegPool(EMjCameraMode::InstanceSegmentation, CamA, PoolA);
+    TestTrue(TEXT("pool has entries after first acquire"), PoolA.Num() > 0);
+
+    TArray<UPrimitiveComponent*> PoolB;
+    Viz->AcquireSegPool(EMjCameraMode::InstanceSegmentation, CamB, PoolB);
+    TestEqual(TEXT("second acquire sees same pool size"), PoolB.Num(), PoolA.Num());
+    if (PoolA.Num() > 0 && PoolB.Num() > 0)
+    {
+        TestEqual(TEXT("pool entries are shared"), PoolA[0], PoolB[0]);
+    }
+
+    // First release — pool should still exist because CamB still subscribed.
+    Viz->ReleaseSegPool(EMjCameraMode::InstanceSegmentation, CamA);
+    TArray<UPrimitiveComponent*> Snapshot;
+    Viz->GetSegPoolSiblings(EMjCameraMode::InstanceSegmentation, Snapshot);
+    TestTrue(TEXT("pool still alive after one release"), Snapshot.Num() > 0);
+
+    // Final release — pool should be destroyed.
+    Viz->ReleaseSegPool(EMjCameraMode::InstanceSegmentation, CamB);
+    Viz->GetSegPoolSiblings(EMjCameraMode::InstanceSegmentation, Snapshot);
+    TestEqual(TEXT("pool empty after last release"), Snapshot.Num(), 0);
 
     S.Cleanup();
     return true;

--- a/docs/features.md
+++ b/docs/features.md
@@ -83,11 +83,11 @@ See [Debug Visualization](guides/debug_visualization.md) for the full hotkey tab
 
 ## Camera System
 
-- **MjCamera**: scene capture attached to MuJoCo sites, streams via ZMQ, respects post-process volumes
+- **MjCamera**: scene capture attached to MuJoCo sites; per-camera `CaptureMode` for photoreal RGB, depth, semantic segmentation, or instance segmentation; streams via ZMQ; respects post-process volumes
 - **MjOrbitCamera**: auto-orbiting cinematic camera with target detection, height oscillation, configurable focal length
 - **MjKeyframeCamera**: waypoint-based camera path with smooth interpolation, `O` key play/pause
 
-See [Blueprint Reference](guides/blueprint_reference.md#mjkeyframecameraactor) for camera API details.
+See [Camera Capture Modes](guides/camera_capture_modes.md) for per-mode behaviour and the simulate-widget preview, and [Blueprint Reference](guides/blueprint_reference.md#mjkeyframecameraactor) for camera API details.
 
 ## Networking (ZMQ)
 

--- a/docs/guides/camera_capture_modes.md
+++ b/docs/guides/camera_capture_modes.md
@@ -1,0 +1,79 @@
+# Camera Capture Modes
+
+Every `UMjCamera` has a `CaptureMode` property that decides what the render target contains. One mode per camera — spawn multiple cameras if you need multiple streams (RGB + depth + masks) from the same viewpoint.
+
+| Mode | Output | Render target format | Scene capture source |
+|---|---|---|---|
+| `Real` (default) | Photoreal RGB. Matches viewport look, respects post-process volumes. | `RTF_RGBA8_SRGB` | `SCS_FinalToneCurveHDR` |
+| `Depth` | Linear scene depth in centimetres, single float per pixel. | `RTF_R32f` | `SCS_SceneDepth` |
+| `SemanticSegmentation` | Per-actor-class flat tint. Two instances of the same Blueprint share a colour; different Blueprints get different colours. | `RTF_RGBA8` | `SCS_FinalToneCurveHDR` + `PRM_UseShowOnlyList` |
+| `InstanceSegmentation` | Per-body unique tint. Every rigid body gets its own hue. | `RTF_RGBA8` | `SCS_FinalToneCurveHDR` + `PRM_UseShowOnlyList` |
+
+---
+
+## Configuring a camera
+
+Set `CaptureMode` on a `UMjCamera` component in the Details panel. For `Depth`, also set `DepthNearCm` (default 10 cm) and `DepthFarCm` (default 10000 cm) — the UI preview and raw depth values are normalised against this range.
+
+`CaptureMode` is read at `SetStreamingEnabled(true)` time. To change mode on a running camera, toggle streaming off and on:
+
+```cpp
+Cam->SetStreamingEnabled(false);
+Cam->CaptureMode = EMjCameraMode::Depth;
+Cam->SetStreamingEnabled(true);
+```
+
+Or, from the simulate widget, reselect the articulation (which rebinds all feed entries).
+
+---
+
+## Coexistence — multiple modes in one frame
+
+Seg modes work without swapping materials on the real meshes, so an RGB camera and a seg camera can stream simultaneously in the same frame with no contamination either way.
+
+Under the hood, `UMjDebugVisualizer` maintains a refcounted **sibling-mesh pool** per seg mode. The first seg camera that streams triggers the pool build; additional cameras on the same mode share it; the pool is torn down when the last subscriber unsubscribes.
+
+- Sibling components duplicate every articulation visual mesh and every Quick-Convert static mesh with an unlit tint MID.
+- They are `bVisibleInSceneCaptureOnly = true` and also disable reflection captures, sky captures, ray-tracing contribution, distance-field lighting, and dynamic indirect lighting — so secondary lighting passes can't leak a faint tinge into the main viewport.
+- Seg cameras use `PrimitiveRenderMode = PRM_UseShowOnlyList` to render only their pool.
+- Non-seg URLab cameras (`Real`, `Depth`) refresh their `HiddenComponents` list against the live pools each tick so a late-starting seg camera never contaminates a running RGB stream.
+
+Cost: up to 3 components per body while both seg pools are active (original + instance sibling + semantic sibling). Each view still draws N primitives — per-view draw count is unchanged. Pools are lazy, so RGB-only sessions pay zero.
+
+---
+
+## Simulate widget preview
+
+The simulate widget's camera panel shows every `UMjCamera` on the selected articulation, each rendering its configured mode live. No extra setup — the feed entry inspects `CaptureMode` and picks the right display path:
+
+- `Real` / `SemanticSegmentation` / `InstanceSegmentation` — the render target binds directly as the slate brush resource.
+- `Depth` — an R32f RT can't be a slate brush. The entry CPU-copies the R channel each tick into a BGRA `UTexture2D`, mapping `depth ∈ [DepthNearCm, DepthFarCm]` to grayscale `[0, 255]`, and binds that texture instead.
+
+The depth preview path is synchronous (`ReadLinearColorPixels` flushes rendering commands). Fine for debug UI; if you need headless depth capture at full framerate, use the render-target readback directly in Blueprint or C++ rather than the widget preview.
+
+---
+
+## ZMQ broadcast
+
+`bEnableZmqBroadcast` continues to work for `Real`, `SemanticSegmentation`, and `InstanceSegmentation` — the existing BGRA worker transports all three.
+
+`Depth` mode skips ZMQ broadcast (a float-transport path isn't wired yet) and logs a one-shot warning. Track the depth-stream follow-up if you need it.
+
+---
+
+## Known v1 limitations
+
+- **Seg tints are lit-shaded, not flat.** Seg cameras use `SCS_FinalToneCurveHDR` because `BasicShapeMaterial`'s `Color` parameter isn't wired directly to the BaseColor G-buffer. Scene lighting therefore modulates the tint. Good enough for visual debugging; not pixel-exact for ground-truth segmentation masks. The cleanest fix is a plugin-shipped unlit parent material — on the roadmap.
+- **Mode changes mid-PIE require toggling streaming off/on.** The render target format is mode-specific (`RTF_RGBA8` vs `RTF_R32f`), and live reconfiguration isn't wired.
+- **Runtime articulation spawn.** The sibling pool is built on first seg subscriber. Articulations or Quick-Convert props that spawn *after* a seg camera is already streaming won't appear in its output until the pool is rebuilt (toggle that seg camera's streaming off/on to force a rebuild).
+- **Third-party `USceneCaptureComponent2D`.** User-authored scene captures outside URLab's management won't automatically hide siblings — they'll see them as regular primitives (since siblings are `bVisibleInSceneCaptureOnly = true`, they *are* visible to scene captures by definition). Add the sibling pool to that component's `HiddenComponents` manually if this is a problem.
+
+---
+
+## Implementation references
+
+- Mode enum + per-camera state — [MjCameraTypes.h](../../Source/URLab/Public/MuJoCo/Components/Sensors/MjCameraTypes.h), [MjCamera.h](../../Source/URLab/Public/MuJoCo/Components/Sensors/MjCamera.h)
+- Per-mode render target + scene-capture setup — [MjCamera.cpp::SetupRenderTarget](../../Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp)
+- Pool lifecycle — [MjDebugVisualizer.cpp::AcquireSegPool / BuildSegPool / DestroySegPool](../../Source/URLab/Private/MuJoCo/Core/MjDebugVisualizer.cpp)
+- Depth preview — [MjCameraFeedEntry.cpp::UpdateDepthPreview](../../Source/URLab/Private/UI/MjCameraFeedEntry.cpp)
+- Automation coverage — `URLab.Camera.*` in [MjCameraTests.cpp](../../Source/URLabEditor/Private/Tests/MjCameraTests.cpp)

--- a/docs/guides/debug_visualization.md
+++ b/docs/guides/debug_visualization.md
@@ -96,13 +96,11 @@ No physics, no collision, no shadow casting, not selectable in the viewport.
 
 ## Camera interaction (known issue)
 
-Because the overlays swap real materials on real `UStaticMeshComponent`s, anything rendering the level — `USceneCaptureComponent2D`, `UMjCamera`, screenshot tools — captures the overlay, not the underlying scene. That's desirable for synthetic-data pipelines (Semantic Segmentation mode gives you free ground-truth masks) but unwanted if you need the RGB observation stream to stay photoreal.
+Because the hotkey-6 overlay swaps real materials on real `UStaticMeshComponent`s, anything rendering the level — `USceneCaptureComponent2D`, `UMjCamera`, screenshot tools — captures the overlay, not the underlying scene. The overlay is fundamentally a viewport-debug tool.
 
-Workarounds today:
-- Toggle the overlay off (`6` until Off) before capturing RGB frames.
-- Script toggles around capture windows if you're generating training data.
+For persistent camera streams that need pure RGB, depth, or segmentation output regardless of viewport state, use per-camera capture modes instead — see [Camera Capture Modes](camera_capture_modes.md). Those modes are orthogonal to hotkey 6: an `InstanceSegmentation` camera outputs masks even when the viewport overlay is off, and a `Real` camera outputs photoreal RGB even when the viewport is showing islands.
 
-A per-camera opt-out flag is on the roadmap.
+If you specifically need the hotkey-6 overlay active while also capturing RGB through a `UMjCamera`, toggle the overlay off (`6` until Off) before the capture window.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ The plugin gives you research-grade contact dynamics alongside Unreal's renderin
 | [Geometry & Collision](guides/geometry_authoring.md) | Primitives, mesh geoms, Quick Convert, heightfields |
 | [Controller Framework](guides/controller_framework.md) | PD, keyframe, and custom controllers |
 | [Debug Visualization](guides/debug_visualization.md) | Hotkey-driven overlays: contacts, joints, islands, segmentation, muscle/tendon tubes |
+| [Camera Capture Modes](guides/camera_capture_modes.md) | Per-camera RGB / depth / semantic + instance segmentation |
 | [Possession & Twist Control](guides/possession_twist.md) | WASD control, spring arm camera |
 | [Scripting with Blueprints](guides/blueprint_reference.md) | Hotkeys, API usage, scripting workflows |
 | [ZMQ Networking & ROS 2](guides/zmq_networking.md) | ZMQ transport, topics, camera streaming |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Geometry & Collision: guides/geometry_authoring.md
     - Controller Framework: guides/controller_framework.md
     - Debug Visualization: guides/debug_visualization.md
+    - Camera Capture Modes: guides/camera_capture_modes.md
     - Possession & Twist Control: guides/possession_twist.md
     - Scripting with Blueprints: guides/blueprint_reference.md
     - ZMQ Networking & ROS 2: guides/zmq_networking.md


### PR DESCRIPTION
## Summary

- Adds a per-camera `CaptureMode` on `UMjCamera` with four modes: `Real` (default, unchanged behaviour), `Depth`, `SemanticSegmentation`, `InstanceSegmentation`.
- Depth uses `RTF_R32f` + `SCS_SceneDepth` with configurable `DepthNearCm` / `DepthFarCm`.
- Seg cameras share a refcounted sibling-mesh pool on `UMjDebugVisualizer`, rendered via `PRM_UseShowOnlyList`. Non-seg URLab cameras auto-hide siblings each tick so an RGB stream and a seg stream can run simultaneously without contamination.
- Simulate widget camera panel renders each bound camera's live output, including a CPU float-to-grayscale depth preview (R32f can't bind directly as a slate brush).
- New guide `docs/guides/camera_capture_modes.md`; the debug-visualization guide points users at per-camera modes for persistent streams.