### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug report
+description: Something in URLab doesn't work as expected.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. A concrete reproduction + logs gets the fix
+        landed far faster than a description alone.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the problem.
+      placeholder: "Importing X.xml produces Y instead of Z"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in all that apply.
+      value: |
+        - Unreal Engine version:
+        - OS (Windows / Linux) and version:
+        - URLab plugin version / commit SHA:
+        - Visual Studio version (Windows only):
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: |
+        Exact steps to trigger the bug. If the issue is import-related, paste
+        the MJCF snippet inline (or attach a minimal `.xml`) and include any
+        referenced mesh file names.
+      placeholder: |
+        1. Drag robot.xml into Content Browser
+        2. Open the generated Blueprint
+        3. Press Play
+        4. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include error messages verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Paste log excerpts from `YourProject/Saved/Logs/*.log` or the
+        `build_all.ps1` transcript. Wrap in a fenced code block.
+      render: shell
+
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm on a supported Unreal Engine version (5.7 or newer), or I've noted why not in the environment block.
+          required: true
+        - label: I reproduced this on the latest `main` (or noted the commit I'm on).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://urlab-sim.github.io/UnrealRoboticsLab/
+    about: Check the guides and API reference before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a new capability or an enhancement to an existing one.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem first, then the shape of the solution.
+        Focused requests get prioritised faster than open-ended ones.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Explain the user-facing need — the "why". Skip the implementation
+        details here; those belong in the section below.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+      description: |
+        What the feature should do from the user's point of view. A list of
+        steps or a short example works well.
+    validations:
+      required: true
+
+  - type: textarea
+    id: api_sketch
+    attributes:
+      label: API sketch (optional)
+      description: |
+        If you already have a mental model of the Blueprint / C++ surface,
+        sketch it here. Don't worry about getting it right — it's a starting
+        point.
+      render: cpp
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered (optional)
+      description: Other approaches, and why they don't fit.
+
+  - type: dropdown
+    id: importance
+    attributes:
+      label: How important is this to you?
+      options:
+        - Nice to have
+        - Blocks my project
+        - Research / exploration
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,58 @@
+<!--
+Thanks for contributing. A maintainer will review this PR and may run it
+locally, but we ask every PR to ship with proof that it builds cleanly
+and the full URLab automation suite passes on your machine.
+-->
+
+## Summary
+
+- <what changed, 1-3 bullets>
+
+## Motivation
+
+<why this change is needed — the problem it solves or the goal it enables>
+
+## Linked issue
+
+Fixes #  /  Related to #
+
+## Proof of compilation
+
+<!--
+Paste the tail of your UnrealBuildTool / Build.bat output, enough to show
+"Result: Succeeded". MuJoCo ASAN_* macro-redefinition warnings are expected
+and can stay in the snippet.
+-->
+
+```
+```
+
+## Test evidence
+
+<!--
+Paste the tail of the URLab automation run. We're looking for the pass
+count and any failures, e.g.
+  grep -cE "Result=\{Success\}" ...
+  159
+  (no failures)
+-->
+
+```
+```
+
+## Manual verification steps
+
+<!--
+What a reviewer should do to spot-check this in the editor:
+ - Any MJCF / asset that's useful (attach or link)
+ - PIE steps (what to click, what to expect)
+ - Before/after screenshots or a short clip for UI / viewport changes
+-->
+
+> **Heads-up:** URLab avoids shipping `.uasset` files where possible so the plugin stays portable across UE versions (engine content is loaded at runtime instead). If your change adds one, call it out in the summary so we can discuss — it's not a blocker, just something we try to minimise.
+
+## Checklist
+
+- [ ] Builds locally against UE 5.7+
+- [ ] Full `URLab.*` automation suite passes
+- [ ] Docs updated for user-facing changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,17 +22,20 @@ Thank you for your interest in contributing. This document covers the process fo
    - Non-UPROPERTY private members use `m_` prefix (`m_model`, `m_data`)
    - All `.h` and `.cpp` files must have the Apache 2.0 license header
 3. Build and verify compilation succeeds.
-4. Run the automation tests via the Session Frontend in the Unreal Editor, or use the `/test` command if you have Claude Code.
+4. Run the URLab automation suite. Two options:
+   - Session Frontend in the Unreal Editor, or
+   - Command line:
+     ```
+     UnrealEditor-Cmd.exe YourProject.uproject -ExecCmds="Automation RunTests URLab;Quit" -Unattended -NullRHI -Log
+     ```
+     The command-line form gives you output you can paste straight into the PR template.
 5. Test your changes in PIE (Play in Editor).
 
 ## Submitting a Pull Request
 
 1. Push to your fork and open a PR against `main`.
-2. In the PR description, include:
-   - What the change does and why
-   - How you tested it (which robots/XMLs, what scenarios)
-   - Any breaking changes
-3. Maintainers will manually build and test before merging, since Unreal Engine projects cannot use standard CI.
+2. Fill in the [PR template](.github/pull_request_template.md). It asks for a summary, motivation, linked issue, **proof that the project builds**, and **proof that the `URLab.*` automation suite passes** on your machine — paste the tail of each command's output into the provided blocks.
+3. We spot-check every PR in the editor before merging, but because Unreal Engine projects can't use standard CI the pasted build + test output is the primary gate. A PR without them will bounce back for that evidence.
 
 ## Code Style
 
@@ -41,11 +44,9 @@ Thank you for your interest in contributing. This document covers the process fo
 - New MJCF attributes should follow the pattern in `/add-mjcf-attribute` (header property, ImportFromXml, ExportTo, test).
 - New component types should follow the existing pattern: subclass `UMjComponent`, implement `RegisterToSpec`, `ExportTo`, `ImportFromXml`, `Bind`.
 
-## Reporting Issues
+## Filing Issues
 
-- Include the Unreal Engine version, OS, and the MuJoCo XML that reproduces the issue.
-- Paste the relevant output log lines (`LogURLab`, `LogURLabImport`, `LogURLabNet`).
-- If it's a compilation error, include the full error message.
+Use the [issue templates](.github/ISSUE_TEMPLATE) to file a bug or a feature request. They collect the environment, reproduction steps, and logs we need upfront — filling them in properly is the fastest path to a fix.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ See [ThirdPartyNotices.txt](ThirdPartyNotices.txt) for full license texts.
 
 ## Contributing
 
-Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Since Unreal Engine projects cannot use standard CI, maintainers manually verify builds before merging.
+Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Since Unreal Engine projects cannot use standard CI, each PR must include proof of a local build and passing tests; maintainers spot-check in the editor before merging.
 
 ## Citation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,9 @@ The [API Reference](api/index.md) is auto-generated from C++ headers on each bui
 | [libzmq](https://zeromq.org) | MPL 2.0 | High-performance messaging |
 
 Full license texts are in `ThirdPartyNotices.txt`.
+
+---
+
+## Contributing
+
+URLab welcomes contributions. See the repo's [CONTRIBUTING.md](https://github.com/URLab-Sim/UnrealRoboticsLab/blob/main/CONTRIBUTING.md) for the workflow, and use the [issue templates](https://github.com/URLab-Sim/UnrealRoboticsLab/issues/new/choose) for bug reports and feature requests.


### PR DESCRIPTION
## Summary

- Bug report and feature request issue forms (YAML), with blank issues disabled and a link to the docs site for help-seekers.
- PR template with `Summary`, `Motivation`, `Linked issue`, `Proof of compilation`, `Test evidence`, `Manual verification steps`, and a short checklist.
- `CONTRIBUTING.md` and `README.md` updated to match the contributor-provides-evidence workflow; `docs/index.md` gets a two-line pointer back to the repo for contribution.

## Motivation

Until now there were no templates, so issues arrived without environment info and PRs arrived without proof of a local build/test pass. The templates make the triage minimum explicit and cut maintainer back-and-forth.

## Manual verification steps

After merge, verify:
- `github.com/URLab-Sim/UnrealRoboticsLab/issues/new/choose` shows Bug / Feature options (no blank issue link).
- Opening a new PR auto-populates with the template.
- The templates render without YAML parse errors on the branch file view.