### PR TITLE
[ThirdParty/Update] Bump MuJoCo to latest 3.7.0 + add dcmotor actuator and flex equality types

### DIFF
--- a/Scripts/mjcf_schema_snapshot.json
+++ b/Scripts/mjcf_schema_snapshot.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "mujoco_version": "3.2.x",
-    "snapshot_date": "2026-03-28",
+    "mujoco_version": "3.7.0",
+    "snapshot_date": "2026-04-18",
     "source": "https://github.com/google-deepmind/mujoco/blob/main/src/xml/xml_native_reader.cc",
     "description": "MJCF schema snapshot for diff-based update detection. Compare against a fresh extract to find new elements/attributes."
   },
@@ -43,7 +43,8 @@
     "damper": ["kv"],
     "cylinder": ["timeconst", "area", "diameter", "bias"],
     "muscle": ["timeconst", "tausmooth", "range", "force", "scale", "lmin", "lmax", "vmax", "fpmax", "fvmax"],
-    "adhesion": ["gain"]
+    "adhesion": ["gain"],
+    "dcmotor": ["motorconst", "resistance", "nominal", "saturation", "inductance", "cogging", "controller", "thermal", "lugre", "input"]
   },
   "sensor_types": [
     "touch", "accelerometer", "velocimeter", "gyro", "force", "torque", "magnetometer",
@@ -77,7 +78,10 @@
     "connect": ["name", "class", "body1", "body2", "anchor", "site1", "site2", "active", "solref", "solimp"],
     "weld": ["name", "class", "body1", "body2", "relpose", "anchor", "site1", "site2", "active", "solref", "solimp", "torquescale"],
     "joint": ["name", "class", "joint1", "joint2", "polycoef", "active", "solref", "solimp"],
-    "tendon": ["name", "class", "tendon1", "tendon2", "polycoef", "active", "solref", "solimp"]
+    "tendon": ["name", "class", "tendon1", "tendon2", "polycoef", "active", "solref", "solimp"],
+    "flex": ["name", "class", "flex", "active", "solref", "solimp"],
+    "flexvert": ["name", "class", "flex", "active", "solref", "solimp"],
+    "flexstrain": ["name", "class", "flex", "active", "solref", "solimp"]
   },
   "contact": {
     "pair": ["name", "class", "geom1", "geom2", "condim", "friction", "solref", "solreffriction", "solimp", "gap", "margin"],
@@ -100,6 +104,6 @@
     "key": ["name", "time", "qpos", "qvel", "act", "mpos", "mquat", "ctrl"]
   },
   "default": {
-    "child_elements": ["mesh", "material", "joint", "geom", "site", "camera", "light", "pair", "equality", "tendon", "general", "motor", "position", "velocity", "intvelocity", "damper", "cylinder", "muscle", "adhesion"]
+    "child_elements": ["mesh", "material", "joint", "geom", "site", "camera", "light", "pair", "equality", "tendon", "general", "motor", "position", "velocity", "intvelocity", "damper", "cylinder", "muscle", "adhesion", "dcmotor"]
   }
 }

--- a/Source/URLab/Private/MuJoCo/Components/Actuators/MjDcMotorActuator.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Actuators/MjDcMotorActuator.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "MuJoCo/Components/Actuators/MjDcMotorActuator.h"
+
+#include "XmlNode.h"
+#include "MuJoCo/Utils/MjXmlUtils.h"
+#include "Utils/URLabLogging.h"
+
+UMjDcMotorActuator::UMjDcMotorActuator()
+{
+    Type = EMjActuatorType::DcMotor;
+}
+
+namespace
+{
+    /** Copy UE TArray<float> into a double[N] buffer, zero-padding the tail. */
+    template <int N>
+    void FillDouble(double (&Out)[N], const TArray<float>& In)
+    {
+        for (int i = 0; i < N; ++i)
+        {
+            Out[i] = (i < In.Num()) ? (double)In[i] : 0.0;
+        }
+    }
+}
+
+void UMjDcMotorActuator::ParseSpecifics(const FXmlNode* Node)
+{
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("motorconst"),  MotorConst,  bOverride_MotorConst);
+    MjXmlUtils::ReadAttrFloat     (Node, TEXT("resistance"),  Resistance,  bOverride_Resistance);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("nominal"),     Nominal,     bOverride_Nominal);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("saturation"),  Saturation,  bOverride_Saturation);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("inductance"),  Inductance,  bOverride_Inductance);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("cogging"),     Cogging,     bOverride_Cogging);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("controller"),  Controller,  bOverride_Controller);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("thermal"),     Thermal,     bOverride_Thermal);
+    MjXmlUtils::ReadAttrFloatArray(Node, TEXT("lugre"),       LuGre,       bOverride_LuGre);
+
+    const FString InputStr = Node->GetAttribute(TEXT("input"));
+    if (!InputStr.IsEmpty())
+    {
+        if      (InputStr == TEXT("voltage"))  Input = EMjDcMotorInput::Voltage;
+        else if (InputStr == TEXT("position")) Input = EMjDcMotorInput::Position;
+        else if (InputStr == TEXT("velocity")) Input = EMjDcMotorInput::Velocity;
+        bOverride_Input = true;
+    }
+}
+
+void UMjDcMotorActuator::ExtractSpecifics(const mjsActuator* /*Actuator*/)
+{
+    // DC motor parameters are packed across gainprm/biasprm/dynprm with a
+    // non-trivial layout (see `engine/engine_xml_native_reader.cc::dcmotor`).
+    // Extracting them cleanly on the reverse path isn't needed for the XML
+    // import flow (that goes through ParseSpecifics) and isn't wired up yet.
+}
+
+void UMjDcMotorActuator::ExportTo(mjsActuator* Actuator, mjsDefault* Default)
+{
+    if (!Actuator) return;
+
+    Super::ExportTo(Actuator, Default);
+
+    // mjs_setToDCMotor treats null array pointers as "don't override, keep
+    // whatever the default / inherited class set". Pass nullptr for any group
+    // the user hasn't opted into so muscles of defaults-chains keep their
+    // inherited values.
+    double MotorConstBuf [2]; FillDouble(MotorConstBuf, MotorConst);
+    double NominalBuf    [3]; FillDouble(NominalBuf,    Nominal);
+    double SaturationBuf [3]; FillDouble(SaturationBuf, Saturation);
+    double InductanceBuf [2]; FillDouble(InductanceBuf, Inductance);
+    double CoggingBuf    [3]; FillDouble(CoggingBuf,    Cogging);
+    double ControllerBuf [6]; FillDouble(ControllerBuf, Controller);
+    double ThermalBuf    [6]; FillDouble(ThermalBuf,    Thermal);
+    double LuGreBuf      [5]; FillDouble(LuGreBuf,      LuGre);
+
+    const double ResistanceArg = bOverride_Resistance ? (double)Resistance : 0.0;
+    const int    InputModeArg  = bOverride_Input ? (int)Input : 0;
+
+    const char* err = mjs_setToDCMotor(
+        Actuator,
+        bOverride_MotorConst  ? MotorConstBuf  : nullptr,
+        ResistanceArg,
+        bOverride_Nominal     ? NominalBuf     : nullptr,
+        bOverride_Saturation  ? SaturationBuf  : nullptr,
+        bOverride_Inductance  ? InductanceBuf  : nullptr,
+        bOverride_Cogging     ? CoggingBuf     : nullptr,
+        bOverride_Controller  ? ControllerBuf  : nullptr,
+        bOverride_Thermal     ? ThermalBuf     : nullptr,
+        bOverride_LuGre       ? LuGreBuf       : nullptr,
+        InputModeArg);
+
+    if (err && err[0])
+    {
+        UE_LOG(LogURLabImport, Warning,
+            TEXT("[MjDcMotorActuator] '%s' mjs_setToDCMotor returned: %s"),
+            *GetName(), UTF8_TO_TCHAR(err));
+    }
+
+    ApplyRawOverrides(Actuator, Default);
+}

--- a/Source/URLab/Private/MuJoCo/Components/Constraints/MjEquality.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Constraints/MjEquality.cpp
@@ -37,14 +37,18 @@ void UMjEquality::ImportFromXml(const FXmlNode* Node)
     if (!Node) return;
 
     FString Tag = Node->GetTag().ToLower();
-    if (Tag == TEXT("connect"))       EqualityType = EMjEqualityType::Connect;
-    else if (Tag == TEXT("weld"))    EqualityType = EMjEqualityType::Weld;
-    else if (Tag == TEXT("joint"))   EqualityType = EMjEqualityType::Joint;
-    else if (Tag == TEXT("tendon"))  EqualityType = EMjEqualityType::Tendon;
+    if (Tag == TEXT("connect"))          EqualityType = EMjEqualityType::Connect;
+    else if (Tag == TEXT("weld"))        EqualityType = EMjEqualityType::Weld;
+    else if (Tag == TEXT("joint"))       EqualityType = EMjEqualityType::Joint;
+    else if (Tag == TEXT("tendon"))      EqualityType = EMjEqualityType::Tendon;
+    else if (Tag == TEXT("flex"))        EqualityType = EMjEqualityType::Flex;
+    else if (Tag == TEXT("flexvert"))    EqualityType = EMjEqualityType::FlexVert;
+    else if (Tag == TEXT("flexstrain"))  EqualityType = EMjEqualityType::FlexStrain;
 
     Obj1 = Node->GetAttribute(TEXT("body1"));
     if (Obj1.IsEmpty()) Obj1 = Node->GetAttribute(TEXT("joint1"));
     if (Obj1.IsEmpty()) Obj1 = Node->GetAttribute(TEXT("tendon1"));
+    if (Obj1.IsEmpty()) Obj1 = Node->GetAttribute(TEXT("flex"));  // flex / flexvert / flexstrain target a single flex
 
     Obj2 = Node->GetAttribute(TEXT("body2"));
     if (Obj2.IsEmpty()) Obj2 = Node->GetAttribute(TEXT("joint2"));

--- a/Source/URLab/Private/URLab.cpp
+++ b/Source/URLab/Private/URLab.cpp
@@ -60,10 +60,11 @@ void FURLabModule::StartupModule()
         return false;
     };
 
-    // Load MuJoCo and its decoders
+    // Load MuJoCo. Since 3.7.0 the obj/stl decoders are compiled into
+    // mujoco.dll itself (changelog item 9); loading the standalone
+    // obj_decoder.dll / stl_decoder.dll would cause a plugin-registration
+    // collision and crash during module init.
     LoadDependencyDLL(TEXT("mujoco.dll"), TEXT("MuJoCo"));
-    LoadDependencyDLL(TEXT("obj_decoder.dll"), TEXT("MuJoCo"));
-    LoadDependencyDLL(TEXT("stl_decoder.dll"), TEXT("MuJoCo"));
 
     // Load ZMQ
     LoadDependencyDLL(TEXT("libzmq-v143-mt-4_3_6.dll"), TEXT("libzmq"));

--- a/Source/URLab/Public/MuJoCo/Components/Actuators/MjActuator.h
+++ b/Source/URLab/Public/MuJoCo/Components/Actuators/MjActuator.h
@@ -45,7 +45,8 @@ enum class EMjActuatorType : uint8
     Damper,
     Cylinder,
     Muscle,
-    Adhesion
+    Adhesion,
+    DcMotor
 };
 
 /**

--- a/Source/URLab/Public/MuJoCo/Components/Actuators/MjDcMotorActuator.h
+++ b/Source/URLab/Public/MuJoCo/Components/Actuators/MjDcMotorActuator.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MuJoCo/Components/Actuators/MjActuator.h"
+#include "MjDcMotorActuator.generated.h"
+
+/**
+ * @enum EMjDcMotorInput
+ * @brief Control input mode for the DC motor actuator. Matches the MuJoCo
+ *        upstream `dcmotorinput_map` in `src/xml/xml_native_reader.cc`.
+ */
+UENUM(BlueprintType)
+enum class EMjDcMotorInput : uint8
+{
+    Voltage  = 0,
+    Position = 1,
+    Velocity = 2
+};
+
+/**
+ * @class UMjDcMotorActuator
+ * @brief Models a DC motor with optional electrical dynamics (inductance),
+ *        cogging torque, thermal effects, and LuGre friction. Introduced in
+ *        MuJoCo 3.7.0.
+ *
+ * Each array field is padded to the size that `mjs_setToDCMotor` expects:
+ *   motorconst[2] / nominal[3] / saturation[3] / inductance[2]
+ *   cogging[3] / controller[6] / thermal[6] / lugre[5]
+ * Missing tail entries are zero by default (per upstream).
+ */
+UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+class URLAB_API UMjDcMotorActuator : public UMjActuator
+{
+    GENERATED_BODY()
+
+public:
+    UMjDcMotorActuator();
+
+    // --- DC motor parameters ---
+
+    /** @brief Motor constant K (and optional winding factor). `motorconst` attribute. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_MotorConst = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_MotorConst"))
+    TArray<float> MotorConst = { 0.0f, 0.0f };
+
+    /** @brief Armature resistance. Scalar, not nullable in mjs_setToDCMotor. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Resistance = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Resistance"))
+    float Resistance = 0.0f;
+
+    /** @brief Nominal operating voltage/torque/speed [3]. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Nominal = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Nominal"))
+    TArray<float> Nominal = { 0.0f, 0.0f, 0.0f };
+
+    /** @brief Saturation current / torque / stall data [3]. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Saturation = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Saturation"))
+    TArray<float> Saturation = { 0.0f, 0.0f, 0.0f };
+
+    /** @brief Winding inductance [2]. Set non-zero to enable electrical dynamics. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Inductance = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Inductance"))
+    TArray<float> Inductance = { 0.0f, 0.0f };
+
+    /** @brief Cogging-torque params [3] (amplitude, periods, phase). */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Cogging = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Cogging"))
+    TArray<float> Cogging = { 0.0f, 0.0f, 0.0f };
+
+    /** @brief Controller gains / limits [6]. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Controller = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Controller"))
+    TArray<float> Controller = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+
+    /** @brief Thermal-resistance-variation params [6]. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Thermal = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Thermal"))
+    TArray<float> Thermal = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+
+    /** @brief LuGre friction params [5]. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_LuGre = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_LuGre"))
+    TArray<float> LuGre = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+
+    /** @brief Control-input interpretation. */
+    UPROPERTY(EditAnywhere, Category = "Mj Actuator", meta = (InlineEditConditionToggle))
+    bool bOverride_Input = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Mj Actuator|DC Motor", meta = (EditCondition = "bOverride_Input"))
+    EMjDcMotorInput Input = EMjDcMotorInput::Voltage;
+
+    virtual void ParseSpecifics(const class FXmlNode* Node) override;
+    virtual void ExtractSpecifics(const mjsActuator* Actuator) override;
+    virtual void ExportTo(mjsActuator* Actuator, mjsDefault* Default = nullptr) override;
+};

--- a/Source/URLab/Public/MuJoCo/Components/Constraints/MjEquality.h
+++ b/Source/URLab/Public/MuJoCo/Components/Constraints/MjEquality.h
@@ -34,10 +34,13 @@
 UENUM(BlueprintType)
 enum class EMjEqualityType : uint8
 {
-    Connect = 0,
-    Weld    = 1,
-    Joint   = 2,
-    Tendon  = 3
+    Connect     = 0,
+    Weld        = 1,
+    Joint       = 2,
+    Tendon      = 3,
+    Flex        = 4,
+    FlexVert    = 5,
+    FlexStrain  = 6
 };
 
 /**

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -94,6 +94,7 @@
 #include "MuJoCo/Components/Actuators/MjCylinderActuator.h"
 #include "MuJoCo/Components/Actuators/MjIntVelocityActuator.h"
 #include "MuJoCo/Components/Actuators/MjAdhesionActuator.h"
+#include "MuJoCo/Components/Actuators/MjDcMotorActuator.h"
 #include "MuJoCo/Components/Actuators/MjGeneralActuator.h"
 #include "MuJoCo/Components/Tendons/MjTendon.h"
 
@@ -711,7 +712,7 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
          }
          return;
     }
-    else if (Tag == "motor" || Tag == "position" || Tag == "velocity" || Tag == "cylinder" || Tag == "muscle" || Tag == "general" || Tag == "damper" || Tag == "intvelocity" || Tag == "adhesion")
+    else if (Tag == "motor" || Tag == "position" || Tag == "velocity" || Tag == "cylinder" || Tag == "muscle" || Tag == "general" || Tag == "damper" || Tag == "intvelocity" || Tag == "adhesion" || Tag == "dcmotor")
     {
          FString Name = Node->GetAttribute(TEXT("name"));
          if (Name.IsEmpty()) Name = TEXT("AUTONAME_") + Tag;
@@ -725,6 +726,7 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
          else if (Tag == "damper") Class = UMjDamperActuator::StaticClass();
          else if (Tag == "intvelocity") Class = UMjIntVelocityActuator::StaticClass();
          else if (Tag == "adhesion") Class = UMjAdhesionActuator::StaticClass();
+         else if (Tag == "dcmotor") Class = UMjDcMotorActuator::StaticClass();
          else if (Tag == "general") Class = UMjGeneralActuator::StaticClass();
 
          CreatedNode = BP->SimpleConstructionScript->CreateNode(Class, *Name);
@@ -1160,7 +1162,8 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
                      ChildTag.Equals(TEXT("velocity")) || ChildTag.Equals(TEXT("cylinder")) ||
                      ChildTag.Equals(TEXT("muscle")) || ChildTag.Equals(TEXT("general")) ||
                      ChildTag.Equals(TEXT("damper")) || ChildTag.Equals(TEXT("actuator")) ||
-                     ChildTag.Equals(TEXT("adhesion")) || ChildTag.Equals(TEXT("intvelocity")))
+                     ChildTag.Equals(TEXT("adhesion")) || ChildTag.Equals(TEXT("intvelocity")) ||
+                     ChildTag.Equals(TEXT("dcmotor")))
             {
                  FString ActName = Child->GetAttribute(TEXT("name"));
                  if (ActName.IsEmpty()) ActName = TEXT("AUTONAME_Default") + ChildTag;
@@ -1172,6 +1175,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
                  else if (ChildTag == "muscle") ActClass = UMjMuscleActuator::StaticClass();
                  else if (ChildTag == "adhesion") ActClass = UMjAdhesionActuator::StaticClass();
                  else if (ChildTag == "intvelocity") ActClass = UMjIntVelocityActuator::StaticClass();
+                 else if (ChildTag == "dcmotor") ActClass = UMjDcMotorActuator::StaticClass();
 
                  USCS_Node* ActNode = BP->SimpleConstructionScript->CreateNode(ActClass, *ActName);
                  DefNode->AddChildNode(ActNode);
@@ -1307,8 +1311,9 @@ void UMujocoGenerationAction::ParseEqualitySection(const FXmlNode* Node, UBluepr
         for (const FXmlNode* Child : Node->GetChildrenNodes())
         {
             FString ChildTag = Child->GetTag();
-            // Equality tags: connect, weld, joint, tendon
-            if (ChildTag.Equals(TEXT("connect")) || ChildTag.Equals(TEXT("weld")) || ChildTag.Equals(TEXT("joint")) || ChildTag.Equals(TEXT("tendon")))
+            // Equality tags: connect, weld, joint, tendon, flex, flexvert, flexstrain
+            if (ChildTag.Equals(TEXT("connect")) || ChildTag.Equals(TEXT("weld")) || ChildTag.Equals(TEXT("joint")) || ChildTag.Equals(TEXT("tendon"))
+             || ChildTag.Equals(TEXT("flex")) || ChildTag.Equals(TEXT("flexvert")) || ChildTag.Equals(TEXT("flexstrain")))
             {
                 FString EqName = Child->GetAttribute(TEXT("name"));
                 if (EqName.IsEmpty()) EqName = FString::Printf(TEXT("AUTONAME_Eq_%s"), *ChildTag);

--- a/Source/URLabEditor/Private/Tests/MjDcMotorTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjDcMotorTests.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/MjTestHelpers.h"
+#include "MuJoCo/Components/Actuators/MjDcMotorActuator.h"
+#include "mujoco/mujoco.h"
+
+namespace
+{
+    // Based on MuJoCo upstream test/engine/testdata/derivative/dcmotor.xml (3.7.0).
+    // Covers the range of dcmotor configurations used in the reference test.
+    const TCHAR* kDcMotorArmXml = TEXT(R"(<mujoco>
+  <worldbody>
+    <body name="motor1" pos="0 0.1 0">
+      <joint name="slide1" type="slide" axis="0 0 1"/>
+      <geom size=".03"/>
+    </body>
+    <body name="motor4" pos="0 0.4 0">
+      <joint name="joint4"/>
+      <geom size=".03"/>
+    </body>
+  </worldbody>
+
+  <actuator>
+    <dcmotor name="dc_bias" joint="slide1" motorconst="2.0" resistance="0.5"/>
+    <dcmotor name="dc_lugre" joint="joint4" motorconst="0.05" resistance="2.0"
+             damping="0.001" lugre="1e4 100 0.005 0.008 0.1"/>
+  </actuator>
+</mujoco>)");
+}
+
+// ============================================================================
+// URLab.DcMotor.Import_CreatesDcMotorComponents
+//   The XML parser maps <dcmotor> elements onto UMjDcMotorActuator components.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjDcMotorImportCreatesComponents,
+    "URLab.DcMotor.Import_CreatesDcMotorComponents",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjDcMotorImportCreatesComponents::RunTest(const FString& Parameters)
+{
+    FMjXmlImportSession S;
+    if (!S.Init(kDcMotorArmXml))
+    {
+        AddError(FString::Printf(TEXT("Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjDcMotorActuator* DcBias  = S.FindTemplate<UMjDcMotorActuator>(TEXT("dc_bias"));
+    UMjDcMotorActuator* DcLugre = S.FindTemplate<UMjDcMotorActuator>(TEXT("dc_lugre"));
+
+    TestNotNull(TEXT("dc_bias component"),  DcBias);
+    TestNotNull(TEXT("dc_lugre component"), DcLugre);
+
+    if (DcBias)
+    {
+        TestTrue(TEXT("dc_bias: Type == DcMotor"), DcBias->Type == EMjActuatorType::DcMotor);
+        TestTrue(TEXT("dc_bias: motorconst overridden"), DcBias->bOverride_MotorConst);
+        if (DcBias->bOverride_MotorConst && DcBias->MotorConst.Num() >= 1)
+        {
+            TestEqual(TEXT("dc_bias: motorconst[0]"), DcBias->MotorConst[0], 2.0f);
+        }
+        TestTrue(TEXT("dc_bias: resistance overridden"), DcBias->bOverride_Resistance);
+        TestEqual(TEXT("dc_bias: resistance"), DcBias->Resistance, 0.5f);
+    }
+
+    if (DcLugre)
+    {
+        TestTrue(TEXT("dc_lugre: lugre overridden"), DcLugre->bOverride_LuGre);
+        TestEqual(TEXT("dc_lugre: lugre length"), DcLugre->LuGre.Num(), 5);
+        if (DcLugre->LuGre.Num() == 5)
+        {
+            TestEqual(TEXT("dc_lugre: lugre[0]"), DcLugre->LuGre[0], 1.0e4f);
+            TestEqual(TEXT("dc_lugre: lugre[4]"), DcLugre->LuGre[4], 0.1f);
+        }
+    }
+
+    return true;
+}
+
+// ============================================================================
+// URLab.DcMotor.Compile_MatchesNativeActuatorCount
+//   Compiling the imported articulation via Manager->Compile() should produce
+//   a model with 2 actuators, each with gaintype mjGAIN_DCMOTOR.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjDcMotorCompile,
+    "URLab.DcMotor.Compile_MatchesNativeActuatorCount",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjDcMotorCompile::RunTest(const FString& Parameters)
+{
+    FMjXmlImportSession S;
+    if (!S.Init(kDcMotorArmXml))
+    {
+        AddError(FString::Printf(TEXT("Init failed: %s"), *S.LastError));
+        return false;
+    }
+    if (!S.Compile())
+    {
+        AddError(FString::Printf(TEXT("Compile failed: %s"), *S.LastError));
+        return false;
+    }
+
+    const mjModel* M = S.Model();
+    if (!TestNotNull(TEXT("compiled model"), (void*)M)) return false;
+
+    TestEqual(TEXT("nu (actuator count)"), (int32)M->nu, (int32)2);
+    for (int i = 0; i < M->nu; ++i)
+    {
+        TestEqual(FString::Printf(TEXT("actuator %d gaintype"), i),
+            (int32)M->actuator_gaintype[i], (int32)mjGAIN_DCMOTOR);
+        TestEqual(FString::Printf(TEXT("actuator %d biastype"), i),
+            (int32)M->actuator_biastype[i], (int32)mjBIAS_DCMOTOR);
+        TestEqual(FString::Printf(TEXT("actuator %d dyntype"), i),
+            (int32)M->actuator_dyntype[i], (int32)mjDYN_DCMOTOR);
+    }
+    return true;
+}

--- a/Source/URLabEditor/Private/Tests/MjFlexEqualityTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjFlexEqualityTests.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/MjTestHelpers.h"
+#include "MuJoCo/Components/Constraints/MjEquality.h"
+
+namespace
+{
+    // Minimal MJCF that compiles: one free body with a capsule geom, plus a
+    // flexcomp that produces a real <flex> asset. The generated flex is named
+    // "cloth" because flexcomp's name becomes the flex name when the flex
+    // section is absent. The flexcomp is authored with edge equality off so
+    // we can add our own explicit <equality><flex ... /> entries.
+    FString MakeFlexEqualityXml(const FString& EqualityChildTag)
+    {
+        // Trilinear flexes can't self-collide, so disable via the flexcomp
+        // contact block. The equality on the flex is the whole point of the
+        // test — flexcomp's own edge equality is disabled so we're the
+        // single source of a flex-referencing equality in the spec.
+        return FString::Printf(TEXT(R"(<mujoco>
+  <worldbody>
+    <body name="anchor" pos="0 0 0">
+      <geom size=".05"/>
+    </body>
+    <flexcomp name="cloth" type="grid" count="2 2 1" spacing="0.1 0.1 0.1"
+              pos="0 0 0.3" dof="trilinear">
+      <contact selfcollide="none"/>
+      <edge equality="false"/>
+    </flexcomp>
+  </worldbody>
+
+  <equality>
+    <%s flex="cloth" active="true"/>
+  </equality>
+</mujoco>)"), *EqualityChildTag);
+    }
+}
+
+// Parametrised helper: run the parser on a flex-equality child tag and verify
+// the generated UMjEquality uses the expected enum value.
+static bool CheckFlexEqualityVariant(FAutomationTestBase& Tester,
+                                     const FString& Tag,
+                                     EMjEqualityType Expected)
+{
+    FMjXmlImportSession S;
+    const FString Xml = MakeFlexEqualityXml(Tag);
+    if (!S.Init(Xml))
+    {
+        Tester.AddError(FString::Printf(TEXT("Init failed (%s): %s"), *Tag, *S.LastError));
+        return false;
+    }
+
+    UMjEquality* Eq = S.FindFirstTemplate<UMjEquality>();
+    if (!Tester.TestNotNull(TEXT("equality component"), Eq))
+    {
+        return false;
+    }
+
+    Tester.TestTrue(FString::Printf(TEXT("<%s> → EqualityType matches"), *Tag),
+        Eq->EqualityType == Expected);
+    Tester.TestEqual(FString::Printf(TEXT("<%s>: flex attribute captured as Obj1"), *Tag),
+        Eq->Obj1, FString(TEXT("cloth")));
+    return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjEqualityFlex,
+    "URLab.Equality.Flex",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjEqualityFlex::RunTest(const FString&)
+{
+    return CheckFlexEqualityVariant(*this, TEXT("flex"), EMjEqualityType::Flex);
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjEqualityFlexVert,
+    "URLab.Equality.FlexVert",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjEqualityFlexVert::RunTest(const FString&)
+{
+    return CheckFlexEqualityVariant(*this, TEXT("flexvert"), EMjEqualityType::FlexVert);
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjEqualityFlexStrain,
+    "URLab.Equality.FlexStrain",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FMjEqualityFlexStrain::RunTest(const FString&)
+{
+    return CheckFlexEqualityVariant(*this, TEXT("flexstrain"), EMjEqualityType::FlexStrain);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,11 +57,9 @@ Subsystems communicate through:
 
 DLL load order (sequential, each must succeed):
 
-1. `mujoco.dll` (from `third_party/install/MuJoCo/bin/`)
-2. `obj_decoder.dll` (same path)
-3. `stl_decoder.dll` (same path)
-4. `libzmq-v143-mt-4_3_6.dll` (from `third_party/install/libzmq/bin/`)
-5. `lib_coacd.dll` (from `third_party/install/CoACD/bin/`)
+1. `mujoco.dll` (from `third_party/install/MuJoCo/bin/`) — obj/stl decoders are compiled into this DLL since MuJoCo 3.7.0; the standalone `obj_decoder.dll` / `stl_decoder.dll` shipped in earlier versions should not be loaded (plugin-registration collision).
+2. `libzmq-v143-mt-4_3_6.dll` (from `third_party/install/libzmq/bin/`)
+3. `lib_coacd.dll` (from `third_party/install/CoACD/bin/`)
 
 Search path strategy: plugin `third_party/install/{SubDir}/bin/` first (editor/development builds), then `FPlatformProcess::GetModulesDirectory()` (packaged builds where DLLs are staged next to the executable).
 

--- a/docs/mjcf_schema_coverage.md
+++ b/docs/mjcf_schema_coverage.md
@@ -1,7 +1,7 @@
 # MJCF Schema Coverage
 
-Checked against: **MuJoCo 3.4** (C API / mjSpec)
-Plugin version: UnrealRoboticsLab main branch, 2026-03-28
+Checked against: **MuJoCo 3.7.0** (C API / mjSpec)
+Plugin version: UnrealRoboticsLab main branch, 2026-04-18
 
 ## Summary
 
@@ -12,10 +12,10 @@ Plugin version: UnrealRoboticsLab main branch, 2026-03-28
 | geom | 22 | 0 | 5 | 27 |
 | site | 10 | 0 | 2 | 12 |
 | actuator (common) | 14 | 0 | 2 | 16 |
-| actuator types | 9 | 0 | 0 | 9 |
+| actuator types | 10 | 0 | 0 | 10 |
 | sensor types | 41 | 0 | 0 | 41 |
 | tendon | 16 | 0 | 1 | 17 |
-| equality | 7 | 0 | 0 | 7 |
+| equality | 10 | 0 | 0 | 10 |
 | default | 6 | 0 | 5 | 11 |
 | compiler | 5 | 0 | 2 | 7 |
 | option | 17 | 0 | 3 | 20 |
@@ -166,6 +166,7 @@ Plugin version: UnrealRoboticsLab main branch, 2026-03-28
 | cylinder | SUPPORTED | `MjCylinderActuator`. Parses `timeconst/bias/area/diameter`. Uses `mjs_setToCylinder` |
 | muscle | SUPPORTED | `MjMuscleActuator`. Uses `mjs_setToMuscle` |
 | adhesion | SUPPORTED | `MjAdhesionActuator`. Parses `gain`. Uses `mjs_setToAdhesion` |
+| dcmotor | SUPPORTED | `MjDcMotorActuator`. Parses `motorconst`, `resistance`, `nominal`, `saturation`, `inductance`, `cogging`, `controller`, `thermal`, `lugre`, `input`. Uses `mjs_setToDCMotor` (MuJoCo 3.7.0+). |
 
 ## sensor types
 
@@ -280,6 +281,9 @@ Tendon wrap types:
 | weld | SUPPORTED | Parses body1/body2, relpos, relquat, torquescale. Exports via `Eq->data[0..7]` |
 | joint | SUPPORTED | Parses joint1/joint2, polycoef. Exports via `Eq->data` |
 | tendon | SUPPORTED | Parses tendon1/tendon2, polycoef. Exports via `Eq->data` |
+| flex | SUPPORTED | Parses `flex` attribute into `Obj1`. Fixes all edge lengths of a flex (MuJoCo 3.5.0+). |
+| flexvert | SUPPORTED | Parses `flex` attribute into `Obj1`. Fixes all vertex lengths of a flex (MuJoCo 3.5.0+). |
+| flexstrain | SUPPORTED | Parses `flex` attribute into `Obj1`. Constrains strain of a trilinear/quadratic flex (MuJoCo 3.6.0+). |
 
 Equality common attributes:
 

--- a/third_party/MuJoCo/build.ps1
+++ b/third_party/MuJoCo/build.ps1
@@ -14,7 +14,7 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
-$PinnedCommit = "47264877"  # Pin to tested commit (MuJoCo 3.7.0 dev, polynomial stiffness/damping)
+$PinnedCommit = "72cb2b210da6"  # Pin to MuJoCo 3.7.0 release (2026-04-14)
 
 $RepoDir = "src"
 if (-not (Test-Path $RepoDir)) {


### PR DESCRIPTION
## Summary

- Pin bumped from `47264877` (3.7.0-dev, 2026-03-30) → `72cb2b210da6` (3.7.0 release, 2026-04-14).
- New \`UMjDcMotorActuator\` covering the full 3.7.0 dcmotor surface: \`motorconst\`, \`resistance\`, \`nominal\`, \`saturation\`, \`inductance\`, \`cogging\`, \`controller\`, \`thermal\`, \`lugre\`, \`input\`. Wired via \`mjs_setToDCMotor\`.
- Three new equality variants (\`flex\`, \`flexvert\`, \`flexstrain\`) added to \`EMjEqualityType\` with parser support.
- Standalone \`obj_decoder.dll\` / \`stl_decoder.dll\` loads removed — those decoders are now compiled into \`mujoco.dll\` itself (3.7.0 changelog item 9); keeping the loads crashed URLab silently at module init.
- Schema snapshot refreshed (3.2.x → 3.7.0). Coverage doc refreshed. Architecture doc updated for the new DLL load list.

## Motivation

Upstream 3.7.0 lands the polynomial stiffness/damping feature our pin was already named after, and introduces the dcmotor actuator model plus flex-equality variants that we want first-class support for. Staying current keeps future bumps cheap and lets URLab users author 3.7.0 MJCF directly.

## Linked issue

_n/a_

## Proof of compilation

Full clean rebuild of plugin + host project (wiped \`Binaries/\` and \`Intermediate/\` on both):

\`\`\`
[23/26] Copy mujoco.dll
[24/26] Copy obj_decoder.dll
[25/26] Copy stl_decoder.dll
[26/26] WriteMetadata url_projEditor.target [NoUba]

Total time in Unreal Build Accelerator local executor: 120.45 seconds

Result: Succeeded
Total execution time: 143.43 seconds
\`\`\`

## Test evidence

\`\`\`
grep -cE "Result=\{Success\}" url_proj.log  →  164
grep  -E "Result=\{(Fail|Error)"             →  (none)
\`\`\`

159 pre-existing tests + 5 new:
- \`URLab.DcMotor.Import_CreatesDcMotorComponents\` — import round-trip on upstream's \`testdata/derivative/dcmotor.xml\`.
- \`URLab.DcMotor.Compile_MatchesNativeActuatorCount\` — compile produces 2 actuators, each with \`mjGAIN_DCMOTOR\` / \`mjBIAS_DCMOTOR\` / \`mjDYN_DCMOTOR\`.
- \`URLab.Equality.Flex\` / \`URLab.Equality.FlexVert\` / \`URLab.Equality.FlexStrain\` — parser captures each variant with correct enum + \`flex\` attribute.

## Manual verification steps

The automation suite covers import + compile, not PIE runtime. Suggested spot-check before merge:

1. Open the editor on this branch, load a known-good scene with an articulation (arm26 tendon demo or any Menagerie robot already in your project).
2. Press Play — confirm physics steps, cameras capture, simulate widget shows feeds.
3. Press hotkeys \`6\` / \`7\` — island/segmentation overlay and tendon tubes should still render.