### PR TITLE
[Enhancement] Add mouse-driven body perturbation (UMjPerturbation)

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
@@ -86,11 +86,7 @@ void UMjQuickConvertComponent::DrawDebugCollision() {
 
         mjtNum _quat[4];
         mju_mat2Quat(_quat, mat);
-        FQuat quat;
-        quat.W = _quat[0];
-        quat.X = _quat[1];
-        quat.Y = _quat[2];
-        quat.Z = _quat[3];
+        const FQuat quat = MjUtils::MjToUERotation(_quat);
 
         if (m_model->mesh_graphadr[meshId] == -1) {
             continue;

--- a/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
@@ -26,6 +26,7 @@
 #include "MuJoCo/Core/MjDebugVisualizer.h"
 #include "MuJoCo/Net/MjNetworkManager.h"
 #include "MuJoCo/Input/MjInputHandler.h"
+#include "MuJoCo/Input/MjPerturbation.h"
 #include "Replay/MjReplayManager.h"
 #include "mujoco/mujoco.h"
 
@@ -49,6 +50,7 @@ AAMjManager::AAMjManager() {
     DebugVisualizer = CreateDefaultSubobject<UMjDebugVisualizer>(TEXT("DebugVisualizer"));
     NetworkManager = CreateDefaultSubobject<UMjNetworkManager>(TEXT("NetworkManager"));
     InputHandler = CreateDefaultSubobject<UMjInputHandler>(TEXT("InputHandler"));
+    Perturbation = CreateDefaultSubobject<UMjPerturbation>(TEXT("Perturbation"));
 }
 
 // --- Forwarding shims: PreCompile, PostCompile, Compile, ApplyOptions ---

--- a/Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp
@@ -24,7 +24,36 @@
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Core/MjDebugVisualizer.h"
 #include "MuJoCo/Core/MjPhysicsEngine.h"
+#include "MuJoCo/Input/MjPerturbation.h"
+#include "Framework/Application/IInputProcessor.h"
+#include "Framework/Application/SlateApplication.h"
+#include "InputCoreTypes.h"
 #include "Kismet/GameplayStatics.h"
+
+// Slate pre-processor that accumulates raw mouse deltas. Pre-processors run
+// ahead of Slate's capture path, so they still see motion while LMB/RMB
+// capture has frozen GetMousePosition / GetInputMouseDelta in PIE.
+class FMjMouseDeltaProcessor : public IInputProcessor
+{
+public:
+    virtual void Tick(const float /*DeltaTime*/, FSlateApplication& /*SlateApp*/, TSharedRef<ICursor> /*Cursor*/) override {}
+
+    virtual bool HandleMouseMoveEvent(FSlateApplication& /*SlateApp*/, const FPointerEvent& MouseEvent) override
+    {
+        Accumulated += MouseEvent.GetCursorDelta();
+        return false;
+    }
+
+    FVector2D Consume()
+    {
+        const FVector2D D = Accumulated;
+        Accumulated = FVector2D::ZeroVector;
+        return D;
+    }
+
+private:
+    FVector2D Accumulated = FVector2D::ZeroVector;
+};
 #include "Cinematics/MjOrbitCameraActor.h"
 #include "Cinematics/MjKeyframeCameraActor.h"
 #include "MuJoCo/Components/Forces/MjImpulseLauncher.h"
@@ -33,6 +62,52 @@
 UMjInputHandler::UMjInputHandler()
 {
     PrimaryComponentTick.bCanEverTick = true;
+}
+
+void UMjInputHandler::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (FSlateApplication::IsInitialized())
+    {
+        MouseDeltaProcessor = MakeShared<FMjMouseDeltaProcessor>();
+        FSlateApplication::Get().RegisterInputPreProcessor(MouseDeltaProcessor);
+    }
+}
+
+void UMjInputHandler::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (MouseDeltaProcessor.IsValid() && FSlateApplication::IsInitialized())
+    {
+        FSlateApplication::Get().UnregisterInputPreProcessor(MouseDeltaProcessor);
+    }
+    MouseDeltaProcessor.Reset();
+
+    if (UWorld* World = GetWorld())
+    {
+        if (APlayerController* PC = World->GetFirstPlayerController())
+        {
+            UnlockCamera(PC);
+        }
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void UMjInputHandler::LockCamera(APlayerController* PC)
+{
+    if (!PC || bPerturbationCameraLocked) return;
+    PC->SetIgnoreLookInput(true);
+    PC->SetIgnoreMoveInput(true);
+    bPerturbationCameraLocked = true;
+}
+
+void UMjInputHandler::UnlockCamera(APlayerController* PC)
+{
+    if (!PC || !bPerturbationCameraLocked) return;
+    PC->SetIgnoreLookInput(false);
+    PC->SetIgnoreMoveInput(false);
+    bPerturbationCameraLocked = false;
 }
 
 void UMjInputHandler::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
@@ -46,6 +121,7 @@ void UMjInputHandler::TickComponent(float DeltaTime, ELevelTick TickType, FActor
     if (PC)
     {
         ProcessHotkeys(PC);
+        ProcessPerturbation(PC, DeltaTime);
     }
 }
 
@@ -150,4 +226,125 @@ void UMjInputHandler::ProcessHotkeys(APlayerController* PC)
             }
         }
     }
+}
+
+void UMjInputHandler::ProcessPerturbation(APlayerController* PC, float DeltaTime)
+{
+    if (!PC) return;
+
+    AAMjManager* Manager = Cast<AAMjManager>(GetOwner());
+    if (!Manager || !Manager->Perturbation) return;
+
+    UMjPerturbation* Pert = Manager->Perturbation;
+
+    FVector CursorOrigin, CursorDirection;
+    if (!PC->DeprojectMousePositionToWorld(CursorOrigin, CursorDirection))
+    {
+        return;
+    }
+
+    FVector CamLoc;
+    FRotator CamRot;
+    PC->GetPlayerViewPoint(CamLoc, CamRot);
+    const FRotationMatrix CamBasis(CamRot);
+    Pert->ClickCamForward = CamBasis.GetScaledAxis(EAxis::X);
+    Pert->ClickCamRight   = CamBasis.GetScaledAxis(EAxis::Y);
+    Pert->ClickCamUp      = CamBasis.GetScaledAxis(EAxis::Z);
+
+    const bool bCtrl = PC->IsInputKeyDown(EKeys::LeftControl) || PC->IsInputKeyDown(EKeys::RightControl);
+    const bool bLmbDown = PC->IsInputKeyDown(EKeys::LeftMouseButton);
+    const bool bRmbDown = PC->IsInputKeyDown(EKeys::RightMouseButton);
+
+    // Double-click LMB: select body.
+    if (!bCtrl && PC->WasInputKeyJustPressed(EKeys::LeftMouseButton))
+    {
+        const float Now = GetWorld() ? GetWorld()->GetTimeSeconds() : 0.0f;
+        constexpr float kDoubleClickWindowS = 0.35f;
+        if (Now - LastLMBPressTime < kDoubleClickWindowS)
+        {
+            Pert->HandleSelect(CursorOrigin, CursorDirection);
+            LastLMBPressTime = -1.0f;
+        }
+        else
+        {
+            LastLMBPressTime = Now;
+        }
+    }
+
+    // Ctrl+LMB press edge: start rotate.
+    const bool bCtrlLmbHeld = bCtrl && bLmbDown;
+    if (bCtrlLmbHeld && !bPrevCtrlLmbHeld && Pert->HasSelection())
+    {
+        Pert->StartRotate();
+        LockCamera(PC);
+    }
+
+    // Ctrl+RMB press edge: start translate.
+    const bool bCtrlRmbHeld = bCtrl && bRmbDown;
+    if (bCtrlRmbHeld && !bPrevCtrlRmbHeld && Pert->HasSelection())
+    {
+        Pert->StartTranslate(CursorOrigin, CursorDirection);
+        LockCamera(PC);
+
+        float MX = 0.f, MY = 0.f;
+        PC->GetMousePosition(MX, MY);
+        TranslateClickScreen = FVector2D(MX, MY);
+        TranslateAccumPixels = FVector2D::ZeroVector;
+    }
+
+    if (Pert->IsDragging() && (bCtrlLmbHeld || bCtrlRmbHeld))
+    {
+        FVector2D RawDelta = FVector2D::ZeroVector;
+        if (MouseDeltaProcessor.IsValid())
+        {
+            RawDelta = MouseDeltaProcessor->Consume();
+        }
+
+        int32 Vw = 0, Vh = 0;
+        PC->GetViewportSize(Vw, Vh);
+        const float InvH = Vh > 0 ? 1.0f / static_cast<float>(Vh) : 1.0f;
+
+        // Translate: UE captures the cursor while RMB is held, so rebuild a
+        // virtual ray from click screen pos + accumulated pixel deltas.
+        // Rotate doesn't need a cursor ray — only the camera basis.
+        FVector RayOrigin    = CursorOrigin;
+        FVector RayDirection = CursorDirection;
+        if (bCtrlRmbHeld)
+        {
+            TranslateAccumPixels += RawDelta;
+            const FVector2D VirtPos = TranslateClickScreen + TranslateAccumPixels;
+            FVector VOrigin, VDir;
+            if (PC->DeprojectScreenPositionToWorld(VirtPos.X, VirtPos.Y, VOrigin, VDir))
+            {
+                RayOrigin    = VOrigin;
+                RayDirection = VDir;
+            }
+        }
+
+        // simulate: reldx = dx/h, reldy = -dy/h (window Y-down → up-positive).
+        Pert->UpdateDrag(RayOrigin, RayDirection,
+                          RawDelta.X * InvH,
+                         -RawDelta.Y * InvH);
+    }
+    else if (MouseDeltaProcessor.IsValid())
+    {
+        // Drop any accumulated motion so the next drag starts with a zero delta.
+        MouseDeltaProcessor->Consume();
+    }
+
+    // Release edges: one LockCamera push on press-edge is balanced by exactly
+    // one UnlockCamera here (UnlockCamera is a no-op if not locked).
+    if (!bCtrlLmbHeld && bPrevCtrlLmbHeld)
+    {
+        Pert->StopDrag();
+        UnlockCamera(PC);
+    }
+    if (!bCtrlRmbHeld && bPrevCtrlRmbHeld)
+    {
+        Pert->StopDrag();
+        UnlockCamera(PC);
+    }
+
+    bPrevCtrlLmbHeld = bCtrlLmbHeld;
+    bPrevCtrlRmbHeld = bCtrlRmbHeld;
 }

--- a/Source/URLab/Private/MuJoCo/Input/MjPerturbation.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjPerturbation.cpp
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "MuJoCo/Input/MjPerturbation.h"
+
+#include "MuJoCo/Core/AMjManager.h"
+#include "MuJoCo/Core/MjPhysicsEngine.h"
+#include "MuJoCo/Components/Geometry/MjGeom.h"
+#include "MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h"
+#include "MuJoCo/Utils/MjUtils.h"
+#include "Utils/URLabLogging.h"
+#include "Components/StaticMeshComponent.h"
+#include "DrawDebugHelpers.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include <mujoco/mujoco.h>
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+namespace
+{
+    // UE direction → MuJoCo direction: unit Y-flip, no cm→m since directions
+    // are unitless.
+    FORCEINLINE void UEToMjDir(const FVector& V, mjtNum Out[3])
+    {
+        Out[0] = V.X;
+        Out[1] = -V.Y;
+        Out[2] = V.Z;
+    }
+}
+
+UMjPerturbation::UMjPerturbation()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+}
+
+void UMjPerturbation::BeginPlay()
+{
+    Super::BeginPlay();
+
+    // Now that URLab's module init has loaded mujoco.dll, this is safe.
+    mjv_defaultPerturb(&Perturb);
+
+    Manager = Cast<AAMjManager>(GetOwner());
+    if (!Manager || !Manager->PhysicsEngine)
+    {
+        UE_LOG(LogURLab, Warning, TEXT("[MjPerturbation] BeginPlay without AAMjManager + PhysicsEngine — disabling."));
+        PrimaryComponentTick.bCanEverTick = false;
+        return;
+    }
+
+    // Matches simulate.cc:2364-2371 — runs on the physics thread under CallbackMutex.
+    Manager->PhysicsEngine->RegisterPreStepCallback(
+        [this](mjModel* m, mjData* d)
+        {
+            if (!m || !d || !Manager || !Manager->PhysicsEngine) return;
+            const bool bRunning = Manager->PhysicsEngine->IsRunning();
+
+            if (bRunning)
+            {
+                // Zero xfrc on every body: otherwise the last force stays
+                // latched after release and the body drifts indefinitely.
+                mju_zero(d->xfrc_applied, 6 * m->nbody);
+                mjv_applyPerturbPose(m, d, &Perturb, 0);
+                mjv_applyPerturbForce(m, d, &Perturb);
+            }
+            else
+            {
+                // Paused: teleport to the reference pose. mj_forward propagates
+                // qpos → xpos/xmat so the render side sees the move.
+                mjv_applyPerturbPose(m, d, &Perturb, 1);
+                if (Perturb.select > 0 && Perturb.active != 0)
+                {
+                    mj_forward(m, d);
+                }
+            }
+        });
+}
+
+void UMjPerturbation::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (IsDragging())
+    {
+        DrawDebugSpring();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Body-id resolution
+// ---------------------------------------------------------------------------
+
+int32 UMjPerturbation::ResolveBodyIdFromActor(const AActor* Actor, const FVector& HitWorldUE) const
+{
+    if (!Actor) return -1;
+
+    // Articulation path: find the nearest UMjGeom to the hit point (any geom
+    // on the actor belongs to a body via Geom->GetMj().body_id).
+    TArray<UMjGeom*> Geoms;
+    const_cast<AActor*>(Actor)->GetComponents<UMjGeom>(Geoms);
+    if (Geoms.Num() > 0)
+    {
+        UMjGeom* Best = nullptr;
+        float BestDist = TNumericLimits<float>::Max();
+        for (UMjGeom* G : Geoms)
+        {
+            if (!G || !G->IsBound()) continue;
+            const float D = FVector::DistSquared(G->GetComponentLocation(), HitWorldUE);
+            if (D < BestDist) { BestDist = D; Best = G; }
+        }
+        if (Best)
+        {
+            return Best->GetMj().body_id;
+        }
+    }
+
+    // Quick-convert path: the hit actor has a UMjQuickConvertComponent.
+    if (UMjQuickConvertComponent* QC = const_cast<AActor*>(Actor)->FindComponentByClass<UMjQuickConvertComponent>())
+    {
+        return QC->GetMjBodyId();
+    }
+
+    return -1;
+}
+
+// ---------------------------------------------------------------------------
+// Public input API
+// ---------------------------------------------------------------------------
+
+void UMjPerturbation::HandleSelect(const FVector& CursorOrigin, const FVector& CursorDirection)
+{
+    if (!Manager || !Manager->PhysicsEngine || !Manager->PhysicsEngine->m_model || !Manager->PhysicsEngine->m_data)
+    {
+        return;
+    }
+
+    // Line trace from cursor. Distance is generous — 1 km covers typical
+    // scene scales.
+    const FVector TraceEnd = CursorOrigin + CursorDirection.GetSafeNormal() * 100000.0f;
+    FHitResult Hit;
+    FCollisionQueryParams Params;
+    Params.bTraceComplex = false;
+    GetWorld()->LineTraceSingleByChannel(Hit, CursorOrigin, TraceEnd, ECC_Visibility, Params);
+
+    int32 BodyId = -1;
+    if (Hit.bBlockingHit && Hit.GetActor())
+    {
+        BodyId = ResolveBodyIdFromActor(Hit.GetActor(), Hit.ImpactPoint);
+    }
+
+    FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
+    const mjModel* m = Manager->PhysicsEngine->m_model;
+    const mjData*  d = Manager->PhysicsEngine->m_data;
+
+    if (BodyId > 0 && BodyId < m->nbody)
+    {
+        // Compute localpos = xmat[sel]^T * (world_hit - xpos[sel])
+        mjtNum HitMj[3];
+        MjUtils::UEToMjPosition(Hit.ImpactPoint, HitMj);
+
+        mjtNum Diff[3];
+        mju_sub3(Diff, HitMj, d->xpos + 3 * BodyId);
+        mju_mulMatTVec(Perturb.localpos, d->xmat + 9 * BodyId, Diff, 3, 3);
+
+        Perturb.select      = BodyId;
+        Perturb.flexselect  = -1;
+        Perturb.skinselect  = -1;
+        Perturb.active      = 0;
+
+        ClickHitWorldUE = Hit.ImpactPoint;
+
+        UE_LOG(LogURLab, Log, TEXT("[MjPerturbation] Selected body %d (%s) at world %s"),
+            BodyId, *Hit.GetActor()->GetName(), *Hit.ImpactPoint.ToString());
+    }
+    else
+    {
+        // Double-click on empty space deselects, matching simulate.
+        Perturb.select     = 0;
+        Perturb.flexselect = -1;
+        Perturb.skinselect = -1;
+        Perturb.active     = 0;
+    }
+}
+
+// Snapshots the click-time pose into Perturb so drag updates are relative.
+// Caller must hold CallbackMutex (reads mjData).
+static void InitPerturbFieldsLocked(mjvPerturb& Perturb, const mjModel* m, const mjData* d,
+                                    mjtNum OutBaseRefPos[3], mjtNum OutBaseRefSelPos[3], mjtNum OutBaseRefQuat[4])
+{
+    const int Sel = Perturb.select;
+    if (Sel <= 0 || Sel >= m->nbody) return;
+
+    mju_copy3(Perturb.refpos, d->xipos + 3 * Sel);
+    mju_mulQuat(Perturb.refquat, d->xquat + 4 * Sel, m->body_iquat + 4 * Sel);
+
+    mjtNum SelWorld[3];
+    mju_mulMatVec3(SelWorld, d->xmat + 9 * Sel, Perturb.localpos);
+    mju_addTo3(SelWorld, d->xpos + 3 * Sel);
+    mju_copy3(Perturb.refselpos, SelWorld);
+
+    // simulate uses a Jacobian-based inverse mass; body mass is a decent proxy.
+    Perturb.localmass = (m->body_mass[Sel] > 0) ? m->body_mass[Sel] : 1.0;
+
+    mju_copy3(OutBaseRefPos,    Perturb.refpos);
+    mju_copy3(OutBaseRefSelPos, Perturb.refselpos);
+    mju_copy4(OutBaseRefQuat,   Perturb.refquat);
+}
+
+void UMjPerturbation::StartTranslate(const FVector& CursorOrigin, const FVector& CursorDirection)
+{
+    if (!HasSelection() || !Manager || !Manager->PhysicsEngine) return;
+    if (!Manager->PhysicsEngine->m_model || !Manager->PhysicsEngine->m_data) return;
+
+    const FVector NormDir = CursorDirection.GetSafeNormal();
+    ClickCamForward = NormDir;
+
+    {
+        FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
+        InitPerturbFieldsLocked(Perturb, Manager->PhysicsEngine->m_model, Manager->PhysicsEngine->m_data,
+                                BaseRefPos, BaseRefSelPos, BaseRefQuat);
+        Perturb.active = mjPERT_TRANSLATE;
+    }
+
+    // Anchor click reference onto the cursor ray at the body's depth, so the
+    // first UpdateDrag tick produces DeltaUE = 0 (no snap-under-cursor if
+    // the mouse moved between select and Ctrl+RMB, or the body drifted).
+    const FVector SelWorldUE(
+        static_cast<float>(Perturb.refselpos[0]) * 100.0f,
+        -static_cast<float>(Perturb.refselpos[1]) * 100.0f,
+        static_cast<float>(Perturb.refselpos[2]) * 100.0f);
+    ClickDepthCm = FVector::DotProduct(SelWorldUE - CursorOrigin, NormDir);
+    if (ClickDepthCm < 1.0f) ClickDepthCm = 1.0f;
+    ClickHitWorldUE = CursorOrigin + NormDir * ClickDepthCm;
+}
+
+void UMjPerturbation::StartRotate()
+{
+    if (!HasSelection() || !Manager || !Manager->PhysicsEngine) return;
+    if (!Manager->PhysicsEngine->m_model || !Manager->PhysicsEngine->m_data) return;
+
+    FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
+    InitPerturbFieldsLocked(Perturb, Manager->PhysicsEngine->m_model, Manager->PhysicsEngine->m_data,
+                            BaseRefPos, BaseRefSelPos, BaseRefQuat);
+    Perturb.active = mjPERT_ROTATE;
+}
+
+void UMjPerturbation::UpdateDrag(const FVector& CursorOrigin, const FVector& CursorDirection,
+                                 float MouseDx, float MouseDy)
+{
+    if (!HasSelection() || !IsDragging() || !Manager || !Manager->PhysicsEngine) return;
+
+    if ((Perturb.active & mjPERT_TRANSLATE) != 0)
+    {
+        const FVector CurTargetUE = CursorOrigin + CursorDirection.GetSafeNormal() * ClickDepthCm;
+        const FVector DeltaUE     = CurTargetUE - ClickHitWorldUE;
+
+        mjtNum DeltaMj[3];
+        MjUtils::UEToMjPosition(DeltaUE, DeltaMj);
+
+        FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
+        for (int i = 0; i < 3; ++i)
+        {
+            Perturb.refpos[i]    = BaseRefPos[i]    + DeltaMj[i];
+            Perturb.refselpos[i] = BaseRefSelPos[i] + DeltaMj[i];
+        }
+    }
+    else if ((Perturb.active & mjPERT_ROTATE) != 0)
+    {
+        // simulate.cc::convert2D + mjv_alignToCamera in MuJoCo coords.
+        // ROTATE_V pre-aligned axis = (dy, 0, dx).
+        mjtNum CamForwardMj[3];
+        UEToMjDir(ClickCamForward.GetSafeNormal(), CamForwardMj);
+
+        const mjtNum VecLocal[3] = { (mjtNum)MouseDy, 0.0, (mjtNum)MouseDx };
+        mjtNum AxisMj[3];
+        mjv_alignToCamera(AxisMj, VecLocal, CamForwardMj);
+
+        const mjtNum Scl = mju_normalize3(AxisMj);
+        if (Scl <= 0.0) return;
+
+        mjtNum QDelta[4];
+        mju_axisAngle2Quat(QDelta, AxisMj, Scl * mjPI * 2.0);
+
+        FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
+        const mjModel* m = Manager->PhysicsEngine->m_model;
+        const mjData*  d = Manager->PhysicsEngine->m_data;
+        if (!m || !d) return;
+
+        // Accumulate onto refquat (simulate.cc::mjv_movePerturb:452).
+        mjtNum Result[4];
+        mju_mulQuat(Result, QDelta, Perturb.refquat);
+        mju_copy4(Perturb.refquat, Result);
+        mju_normalize4(Perturb.refquat);
+
+        // ±90° limit (simulate.cc::mjv_movePerturb:455-481). Without it the
+        // refquat drifts far from the body's pose and the spring misbehaves.
+        const int32 Sel = Perturb.select;
+        if (Sel > 0 && Sel < m->nbody)
+        {
+            mjtNum xiquat[4];
+            mju_mulQuat(xiquat, d->xquat + 4 * Sel, m->body_iquat + 4 * Sel);
+
+            mjtNum q1[4];
+            mju_negQuat(q1, xiquat);
+
+            mjtNum q2[4];
+            mju_mulQuat(q2, q1, Perturb.refquat);
+
+            mjtNum dif[3];
+            mju_quat2Vel(dif, q2, 1);
+            mjtNum scl = mju_normalize3(dif);
+
+            if (scl < -mjPI * 0.5 || scl > mjPI * 0.5)
+            {
+                scl = FMath::Clamp<double>(scl, -mjPI * 0.5, mjPI * 0.5);
+                mju_axisAngle2Quat(q2, dif, scl);
+                mju_mulQuat(Perturb.refquat, xiquat, q2);
+            }
+        }
+    }
+}
+
+void UMjPerturbation::StopDrag()
+{
+    if (!Manager || !Manager->PhysicsEngine) return;
+    FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
+    Perturb.active = 0;
+}
+
+void UMjPerturbation::DrawDebugSpring() const
+{
+    if (!HasSelection() || !Manager || !Manager->PhysicsEngine) return;
+    const mjModel* m = Manager->PhysicsEngine->m_model;
+    const mjData*  d = Manager->PhysicsEngine->m_data;
+    if (!m || !d) return;
+    const int32 Sel = Perturb.select;
+    if (Sel <= 0 || Sel >= m->nbody) return;
+    UWorld* World = GetWorld();
+    if (!World) return;
+
+    mjtNum SelWorldMj[3];
+    mju_mulMatVec3(SelWorldMj, d->xmat + 9 * Sel, Perturb.localpos);
+    mju_addTo3(SelWorldMj, d->xpos + 3 * Sel);
+
+    auto MjPosToUE = [](const mjtNum P[3]) -> FVector {
+        return FVector((float)P[0] * 100.0f, -(float)P[1] * 100.0f, (float)P[2] * 100.0f);
+    };
+    const FVector SelWorldUE = MjPosToUE(SelWorldMj);
+    const FVector RefSelUE   = MjPosToUE(Perturb.refselpos);
+
+    DrawDebugSphere(World, SelWorldUE, 3.0f, 12, FColor::Red, false, -1.0f, 0, 0.5f);
+
+    if ((Perturb.active & mjPERT_TRANSLATE) != 0)
+    {
+        const float Extent = FVector::Dist(SelWorldUE, RefSelUE);
+        const float HeadSize = FMath::Clamp(Extent * 0.25f, 8.0f, 60.0f);
+        DrawDebugDirectionalArrow(World, SelWorldUE, RefSelUE, HeadSize,
+            FColor::Green, false, -1.0f, 0, 1.5f);
+    }
+    else if ((Perturb.active & mjPERT_ROTATE) != 0)
+    {
+        // Tangent arrow (ω × r) — shrinks as the body catches up so the
+        // arrow doesn't wobble when the rotation axis is noisy.
+        mjtNum XIQuat[4];
+        mju_mulQuat(XIQuat, d->xquat + 4 * Sel, m->body_iquat + 4 * Sel);
+        mjtNum NegXI[4];
+        mju_negQuat(NegXI, XIQuat);
+        mjtNum QRel[4];
+        mju_mulQuat(QRel, Perturb.refquat, NegXI);
+
+        mjtNum OmegaMj[3];
+        mju_quat2Vel(OmegaMj, QRel, 1.0);
+
+        mjtNum Rvec[3];
+        mju_sub3(Rvec, SelWorldMj, d->xipos + 3 * Sel);
+
+        mjtNum TangentMj[3];
+        mju_cross(TangentMj, OmegaMj, Rvec);
+
+        // Boost m/rad → cm for visibility.
+        constexpr float TangentVisualGainCm = 200.0f;
+        const FVector TangentUE(
+            (float)TangentMj[0] * TangentVisualGainCm,
+            -(float)TangentMj[1] * TangentVisualGainCm,
+            (float)TangentMj[2] * TangentVisualGainCm);
+
+        const FVector ArrowEnd = SelWorldUE + TangentUE;
+        const float Extent = TangentUE.Size();
+        if (Extent > 2.0f)
+        {
+            const float HeadSize = FMath::Clamp(Extent * 0.25f, 8.0f, 60.0f);
+            DrawDebugDirectionalArrow(World, SelWorldUE, ArrowEnd, HeadSize,
+                FColor::Yellow, false, -1.0f, 0, 1.5f);
+        }
+    }
+}

--- a/Source/URLab/Public/MuJoCo/Core/AMjManager.h
+++ b/Source/URLab/Public/MuJoCo/Core/AMjManager.h
@@ -34,6 +34,7 @@ class UMjPhysicsEngine;
 class UMjDebugVisualizer;
 class UMjNetworkManager;
 class UMjInputHandler;
+class UMjPerturbation;
 class UMjSimulationState;
 
 /**
@@ -78,6 +79,10 @@ public:
     /** @brief Input handler component for keyboard hotkeys. */
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "MuJoCo")
     UMjInputHandler* InputHandler;
+
+    /** @brief Mouse-driven body perturbation (simulate-style Ctrl+LMB/RMB drag). */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "MuJoCo")
+    UMjPerturbation* Perturbation;
     
     // --- Global Access ---
     /** 

--- a/Source/URLab/Public/MuJoCo/Input/MjInputHandler.h
+++ b/Source/URLab/Public/MuJoCo/Input/MjInputHandler.h
@@ -28,6 +28,7 @@
 
 // Forward declarations
 class AAMjManager;
+class FMjMouseDeltaProcessor;
 
 /**
  * @class UMjInputHandler
@@ -41,9 +42,48 @@ class URLAB_API UMjInputHandler : public UActorComponent
 public:
     UMjInputHandler();
 
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
     virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 private:
     /** @brief Processes keyboard hotkeys for simulation control and debug toggles. */
     void ProcessHotkeys(APlayerController* PC);
+
+    /** @brief Drives perturbation gestures: double-click-LMB select, Ctrl+RMB
+     *         translate drag, Ctrl+LMB rotate drag. Release stops drag. */
+    void ProcessPerturbation(APlayerController* PC, float DeltaTime);
+
+    /** @brief Last time LMB was pressed (seconds since startup). Used to
+     *         detect double-clicks within kDoubleClickWindowS seconds. */
+    float LastLMBPressTime = -1.0f;
+
+    /** @brief Previous-frame Ctrl+LMB / Ctrl+RMB held state for press-edge
+     *         detection (matches simulate: Ctrl+LMB rotate, Ctrl+RMB translate). */
+    bool bPrevCtrlLmbHeld = false;
+    bool bPrevCtrlRmbHeld = false;
+
+    /** @brief Whether we currently hold a camera-input lock on the player
+     *         controller. SetIgnoreLookInput/MoveInput are reference-counted,
+     *         so we must balance each push() with exactly one pop(). */
+    bool bPerturbationCameraLocked = false;
+
+    /** @brief Screen-space position of the cursor at Ctrl+RMB press, plus the
+     *         running sum of raw pixel deltas since. We rebuild a "virtual"
+     *         cursor ray from these each tick because UE's RMB capture freezes
+     *         GetMousePosition/DeprojectMousePositionToWorld while held —
+     *         identical reason we needed the Slate pre-processor for LMB. */
+    FVector2D TranslateClickScreen = FVector2D::ZeroVector;
+    FVector2D TranslateAccumPixels = FVector2D::ZeroVector;
+
+    /** Pushes camera lock if not already held. */
+    void LockCamera(class APlayerController* PC);
+    /** Releases camera lock if held. */
+    void UnlockCamera(class APlayerController* PC);
+
+    /** @brief Slate input pre-processor that captures raw mouse deltas from
+     *         FPointerEvent before UE's cursor-capture layer zeroes them out.
+     *         Without this, LMB capture locks GetMousePosition / GetCursorPos
+     *         and any derived delta is zero, breaking rotate. */
+    TSharedPtr<FMjMouseDeltaProcessor> MouseDeltaProcessor;
 };

--- a/Source/URLab/Public/MuJoCo/Input/MjPerturbation.h
+++ b/Source/URLab/Public/MuJoCo/Input/MjPerturbation.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#pragma once
+
+#include <mujoco/mjvisualize.h>
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "MjPerturbation.generated.h"
+
+class AAMjManager;
+
+/**
+ * @class UMjPerturbation
+ * @brief Mouse-driven body perturbation matching MuJoCo `simulate`'s behaviour.
+ *
+ * Input gestures (mirrored from upstream simulate):
+ *  - Double-click LMB on a body → select (no force applied).
+ *  - Ctrl + RMB drag with selection → translate (virtual position spring).
+ *  - Ctrl + LMB drag with selection → rotate (virtual orientation spring).
+ *  - Release button → stop drag; selection persists.
+ *
+ * Uses MuJoCo's own `mjv_applyPerturbForce` every physics pre-step to convert
+ * `refpos`/`refquat`/`refselpos` into `xfrc_applied` — identical spring feel
+ * to simulate. The plugin-side code only has to manage the reference
+ * positions/orientations from UE mouse input.
+ */
+UCLASS(ClassGroup = (MuJoCo), meta = (BlueprintSpawnableComponent))
+class URLAB_API UMjPerturbation : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UMjPerturbation();
+
+    virtual void BeginPlay() override;
+    virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    /** Line-trace from the cursor and, if a body is hit, latch selection.
+     *  Called on double-click LMB (without Ctrl). */
+    void HandleSelect(const FVector& CursorOrigin, const FVector& CursorDirection);
+
+    /** Begin a translate drag (Ctrl+RMB press with a body selected). */
+    void StartTranslate(const FVector& CursorOrigin, const FVector& CursorDirection);
+
+    /** Begin a rotate drag (Ctrl+LMB press with a body selected). */
+    void StartRotate();
+
+    /** Update drag refpos/refselpos/refquat from current cursor + per-frame
+     *  mouse delta. Safe to call every game-tick while active. */
+    void UpdateDrag(const FVector& CursorOrigin, const FVector& CursorDirection,
+                    float MouseDx, float MouseDy);
+
+    /** Stop the current drag (mouse release). Selection persists. */
+    void StopDrag();
+
+    /** Is a body currently latched (pert.select > 0)? */
+    bool HasSelection() const { return Perturb.select > 0; }
+
+    /** Is a drag currently active (LMB/RMB held)? */
+    bool IsDragging() const { return Perturb.active != 0; }
+
+private:
+    friend class UMjInputHandler;
+
+    /** Cached manager (owner). */
+    UPROPERTY(Transient)
+    AAMjManager* Manager = nullptr;
+
+    /** The actual mjv perturb struct passed to mjv_applyPerturbForce. */
+    mjvPerturb Perturb{};
+
+    /** Click-time state used to re-derive refpos each frame. */
+    FVector ClickHitWorldUE = FVector::ZeroVector;   // hit point in UE world space
+    float   ClickDepthCm    = 0.0f;                  // distance from camera to hit along ray
+    FVector ClickCamForward = FVector::ForwardVector;// UE-space at click time
+    FVector ClickCamUp      = FVector::UpVector;
+    FVector ClickCamRight   = FVector::RightVector;
+    mjtNum  BaseRefPos[3]   = {0, 0, 0};
+    mjtNum  BaseRefSelPos[3]= {0, 0, 0};
+    mjtNum  BaseRefQuat[4]  = {1, 0, 0, 0};
+
+    /** Resolve a hit actor to a MuJoCo body_id. Returns <=0 if no match. */
+    int32 ResolveBodyIdFromActor(const class AActor* Actor, const FVector& HitWorldUE) const;
+
+    /** Draw a debug line from the world selection point to the ref target. */
+    void DrawDebugSpring() const;
+};

--- a/docs/features.md
+++ b/docs/features.md
@@ -81,6 +81,12 @@ Hotkey-driven toggles during PIE for contact forces, collision wireframes, joint
 
 See [Debug Visualization](guides/debug_visualization.md) for the full hotkey table and per-mode details.
 
+## Interactive Perturbation
+
+Mouse-driven body manipulation during PIE. Double-click LMB to select, Ctrl+RMB drag to translate, Ctrl+LMB drag to rotate — the same gesture map as MuJoCo's `simulate` viewer. Driven by the upstream `mjv_applyPerturbForce` / `mjv_applyPerturbPose` primitives, so the spring feel is identical. Works while paused for manual pose authoring (pairs well with snapshot keyframe capture).
+
+See [Interactive Perturbation](guides/perturbation.md) for gesture mapping, gizmo reference, and paused-mode workflow.
+
 ## Camera System
 
 - **MjCamera**: scene capture attached to MuJoCo sites; per-camera `CaptureMode` for photoreal RGB, depth, semantic segmentation, or instance segmentation; streams via ZMQ; respects post-process volumes

--- a/docs/guides/perturbation.md
+++ b/docs/guides/perturbation.md
@@ -1,0 +1,55 @@
+# Interactive Perturbation
+
+Mouse-driven manipulation of bodies during PIE. Gesture mapping matches MuJoCo's `simulate` viewer, and under the hood the plugin calls the same `mjv_applyPerturbForce` / `mjv_applyPerturbPose` primitives — so the spring feel, force falloff, and paused-teleport semantics are identical to upstream.
+
+Driven by `UMjPerturbation` (auto-created on `AAMjManager`). `UMjInputHandler` owns the gesture detection.
+
+---
+
+## Gestures
+
+| Input | Action |
+|---|---|
+| **Double-click LMB** on a body | Select. No force applied. Selection persists until you double-click elsewhere or on empty space. |
+| **Ctrl + RMB drag** | Translate the selected body along the cursor plane at the selection depth. |
+| **Ctrl + LMB drag** | Rotate the selected body about the camera-aligned axis. |
+| Release the mouse button | Stop drag. Selection persists, forces clear on the next physics step. |
+
+Camera look/move input is disabled while a drag is active so the cursor motion drives the body rather than the view.
+
+---
+
+## Running vs paused
+
+| State | Behaviour |
+|---|---|
+| **Running** | `mjv_applyPerturbForce` writes a virtual spring force into `xfrc_applied`. The body integrates under physics — it can collide, swing, settle. Release and the force is cleared on the next pre-step. |
+| **Paused** (`P`) | `mjv_applyPerturbPose` teleports the body to the reference pose and `mj_forward` propagates `qpos → xpos`. Hold Ctrl and drag to pose the body statically. Release keeps the pose frozen. |
+
+Combine paused perturbation with the snapshot widget to capture keyframes by hand: pause, drag the body into position, hit **Save Snapshot**, then resume. The snapshot records the current `qpos` / `ctrl` — so the pose you manually dialled in replays exactly.
+
+---
+
+## Gizmos
+
+While a drag is active `UMjPerturbation::DrawDebugSpring` overlays:
+
+- **Red sphere** at the selection point on the body (follows the body through the drag).
+- **Green arrow** during translate: from the selection point to the reference target. Length = position error the spring is solving.
+- **Yellow arrow** during rotate: the tangent direction `ω × r` — the linear motion the rotation spring is trying to produce at the selection point. Naturally shrinks to zero as the body catches up, so it doesn't wobble when the rotation axis changes direction mid-drag.
+
+---
+
+## Implementation notes
+
+- **Selection persists across drags.** Clicking with Ctrl held never reselects; only a plain double-click moves the selection. This avoids fat-finger re-selection during a rotate-then-translate sequence.
+- **Cursor capture workaround.** UE's LMB and RMB capture freezes `GetMousePosition` / `GetInputMouseDelta` during a drag. To get real motion we register a Slate `IInputProcessor` (`FMjMouseDeltaProcessor`) that accumulates raw `FPointerEvent` deltas *before* Slate's capture layer zeroes them. Translate then rebuilds a virtual cursor screen position from the click pos + accumulated pixels and deprojects through that.
+- **No force leak on release.** The pre-step callback zeros `d->xfrc_applied` every running step, matching simulate's contract — otherwise the last force would stay latched on the previously perturbed body and it would drift indefinitely.
+- **Rotation clamp.** The reference quaternion is limited to ±90° relative to the body's current I-frame (same as `simulate.cc::mjv_movePerturb`). Without this the spring can stall or thrash if the ref drifts too far from reality.
+
+---
+
+## See also
+
+- [Debug Visualization](debug_visualization.md) — hotkey reference, including the quick-convert wireframe overlay useful for diagnosing rest-pose issues.
+- MuJoCo upstream: [`simulate.cc::mjv_movePerturb`](https://github.com/google-deepmind/mujoco/blob/main/simulate/simulate.cc) for the reference implementation of the gesture math.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ The plugin gives you research-grade contact dynamics alongside Unreal's renderin
 | [Geometry & Collision](guides/geometry_authoring.md) | Primitives, mesh geoms, Quick Convert, heightfields |
 | [Controller Framework](guides/controller_framework.md) | PD, keyframe, and custom controllers |
 | [Debug Visualization](guides/debug_visualization.md) | Hotkey-driven overlays: contacts, joints, islands, segmentation, muscle/tendon tubes |
+| [Interactive Perturbation](guides/perturbation.md) | Mouse-driven body drag: select, translate, rotate — simulate-compatible gestures |
 | [Camera Capture Modes](guides/camera_capture_modes.md) | Per-camera RGB / depth / semantic + instance segmentation |
 | [Possession & Twist Control](guides/possession_twist.md) | WASD control, spring arm camera |
 | [Scripting with Blueprints](guides/blueprint_reference.md) | Hotkeys, API usage, scripting workflows |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
     - Geometry & Collision: guides/geometry_authoring.md
     - Controller Framework: guides/controller_framework.md
     - Debug Visualization: guides/debug_visualization.md
+    - Interactive Perturbation: guides/perturbation.md
     - Camera Capture Modes: guides/camera_capture_modes.md
     - Possession & Twist Control: guides/possession_twist.md
     - Scripting with Blueprints: guides/blueprint_reference.md


### PR DESCRIPTION
## Summary

- Add `UMjPerturbation` actor-component: mouse-driven body drag during PIE matching MuJoCo `simulate` gestures — double-click LMB to select, Ctrl+RMB drag translate, Ctrl+LMB drag rotate. Dispatches to the upstream `mjv_applyPerturbForce` / `mjv_applyPerturbPose` primitives so the spring feel is identical to simulate, with paused-mode teleport for manual keyframe posing.
- Fix handedness bug in `UMjQuickConvertComponent::DrawDebugCollision`: the quaternion was copied from MuJoCo without the Y-flip every other site uses, so the wireframe overlay appeared mirrored relative to the visual mesh for non-trivial orientations. Switched to the shared `MjUtils::MjToUERotation` util.
- New guide `docs/guides/perturbation.md` (linked from index, features, and mkdocs nav) covering gestures, running-vs-paused workflow (including snapshot capture for manual posing), gizmo reference, and implementation notes.

## Motivation

Interactive perturbation is important for a debugging workflow against articulated robots and scenes — pick a body, yank it, watch how the controller responds. Matching simulate's exact gesture map (and the `mjvPerturb` spring math) keeps the feel consistent for anyone already used to the native viewer, and the paused-mode path doubles as a manual pose-authoring tool when paired with the snapshot widget. The debug-overlay quat fix was surfaced while testing perturbation on Quick-Convert cones — the stationary-pose wireframe mismatch was a pre-existing day-one bug masked until a shape tumbled into a general orientation.

## Linked issue

N/A

## Proof of compilation

\`\`\`
[10/13] Link [x64] UnrealEditor-URLab.lib
[11/13] Link [x64] UnrealEditor-URLabEditor.dll
[12/13] Link [x64] UnrealEditor-URLab.dll
[13/13] WriteMetadata url_projEditor.target [NoUba]

Trace written to file C:/Users/jonat/AppData/Local/UnrealBuildTool/Log.uba with size 7.2kb
Total time in Unreal Build Accelerator local executor: 23.56 seconds

Result: Succeeded
Total execution time: 47.95 seconds
\`\`\`

## Test evidence

\`\`\`
$ grep -cE "Result=\{Success\}" /tmp/urlab_test.log
164
$ grep  -E "Result=\{(Fail|Error)\}" /tmp/urlab_test.log
(no matches)
$ grep -iE "tests performed" /tmp/urlab_test.log
LogAutomationCommandLine: Display: ...Automation Test Queue Empty 164 tests performed.
\`\`\`

## Manual verification steps

1. Open any PIE scene containing at least one articulation and a Quick-Convert prop (a cone or anything with a non-axis-aligned resting orientation works best for the wireframe check).
2. **Perturbation — running:**
    - Double-click LMB on a body. Expect a red marker sphere to appear at the hit point.
    - Hold Ctrl and drag RMB. The body should follow the cursor with a visible green target arrow, camera does not rotate during the drag.
    - Hold Ctrl and drag LMB. The body should rotate about a camera-aligned axis; a yellow tangent arrow appears and shrinks as the body catches up.
    - Release the button. The body falls under gravity / continues under its controller — no lingering force (no drift).
3. **Perturbation — paused:**
    - Press \`P\` to pause.
    - Ctrl+RMB drag to translate or Ctrl+LMB drag to rotate — the body teleports directly to the reference pose.
    - Open the snapshot widget, save a snapshot, resume, then load the snapshot to confirm the pose was captured.
4. **Quick-Convert wireframe fix:**
    - With the same scene, press \`5\` to toggle the Quick-Convert collision wireframe overlay.
    - Rotate a cone (or other non-symmetric prop) into a general orientation via the perturbation above.
    - Expect the magenta wireframe to stay aligned with the visual mesh at rest and during motion. Before this fix, the wireframe was mirrored about the XZ plane.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full \`URLab.*\` automation suite passes (164 / 164)
- [x] Docs updated for user-facing changes