### PR TITLE
Add UMjCapsule primitive with composite engine-mesh visualizer

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjCapsule.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjCapsule.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "MuJoCo/Components/Geometry/Primitives/MjCapsule.h"
+
+#include "MuJoCo/Utils/MjOrientationUtils.h"
+#include "Utils/URLabLogging.h"
+#include "Components/StaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
+
+namespace
+{
+    // Engine-content defaults: Cylinder.Cylinder is 100 cm tall × 100 cm
+    // diameter, Sphere.Sphere is 100 cm diameter. A scale of 1.0 on a
+    // UMjCapsule maps to a 50 cm radius / 50 cm half-length (matches
+    // UMjCylinder's convention). Centimetres-per-metre = 100.
+    constexpr float kCmPerM    = 100.0f;
+    constexpr float kBaseHalf  = 50.0f;   // 50cm half-extent of engine base shape
+    constexpr float kMinScaleZ = 0.001f;  // guard for counter-scale divide
+}
+
+UMjCapsule::UMjCapsule()
+{
+    Type = EMjGeomType::Capsule;
+    bOverride_Type = true;
+}
+
+void UMjCapsule::EnsureVisualizerMesh()
+{
+    if (IsValid(VisualizerShaft) && IsValid(VisualizerCapTop) && IsValid(VisualizerCapBottom)) return;
+
+    UStaticMesh* CylinderMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Cylinder.Cylinder"));
+    UStaticMesh* SphereMesh   = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Sphere.Sphere"));
+
+    auto MakeSubMesh = [&](const FName InName, UStaticMesh* InMesh) -> UStaticMeshComponent*
+    {
+        UStaticMeshComponent* SMC = NewObject<UStaticMeshComponent>(this, InName);
+        if (!SMC) return nullptr;
+        SMC->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+        SMC->SetCollisionResponseToAllChannels(ECR_Overlap);
+        if (InMesh) SMC->SetStaticMesh(InMesh);
+        if (IsRegistered())
+        {
+            SMC->SetupAttachment(this);
+            SMC->RegisterComponent();
+        }
+        return SMC;
+    };
+
+    if (!IsValid(VisualizerShaft))     VisualizerShaft     = MakeSubMesh(TEXT("VisualizerShaft"),     CylinderMesh);
+    if (!IsValid(VisualizerCapTop))    VisualizerCapTop    = MakeSubMesh(TEXT("VisualizerCapTop"),    SphereMesh);
+    if (!IsValid(VisualizerCapBottom)) VisualizerCapBottom = MakeSubMesh(TEXT("VisualizerCapBottom"), SphereMesh);
+
+    UpdateCapTransforms();
+}
+
+void UMjCapsule::OnRegister()
+{
+    Super::OnRegister();
+    EnsureVisualizerMesh();
+
+    auto RegisterIfNeeded = [this](UStaticMeshComponent* SMC)
+    {
+        if (IsValid(SMC) && !SMC->IsRegistered())
+        {
+            SMC->SetupAttachment(this);
+            SMC->RegisterComponent();
+        }
+    };
+    RegisterIfNeeded(VisualizerShaft);
+    RegisterIfNeeded(VisualizerCapTop);
+    RegisterIfNeeded(VisualizerCapBottom);
+
+    UpdateCapTransforms();
+}
+
+void UMjCapsule::UpdateCapTransforms()
+{
+    const FVector ParentScale = GetRelativeScale3D();
+    const float   SafeZ       = FMath::Max(FMath::Abs(ParentScale.Z), kMinScaleZ);
+
+    // Caps inherit the parent's X/Y scale (correct sphere diameter), but
+    // counter-scale on Z so parent's Z stretch doesn't deform them into
+    // ellipsoids. Z-sign preserved to support mirrored (negative-scale) setups.
+    const float CapZ = (ParentScale.Z >= 0.0f ? 1.0f : -1.0f) * (ParentScale.X / SafeZ);
+
+    // Cap centres sit at ±HalfLength world-cm = ±(ParentScale.Z * 50 cm).
+    // Because Z positions are interpreted in the parent's local (un-scaled)
+    // space and then scaled by ParentScale.Z, a constant local ±50 lands at
+    // the correct world position as HalfLength varies with ParentScale.Z.
+    const FVector CapLocalUp   = FVector(0.0f, 0.0f,  kBaseHalf);
+    const FVector CapLocalDown = FVector(0.0f, 0.0f, -kBaseHalf);
+    const FVector CapScale     = FVector(1.0f, 1.0f, CapZ);
+
+    // IsValid() checks cover both null and pending-kill (post-reconstruction
+    // transient state) on top of the UPROPERTY-nulling guarantee.
+    if (IsValid(VisualizerCapTop))
+    {
+        VisualizerCapTop->SetRelativeLocation(CapLocalUp);
+        VisualizerCapTop->SetRelativeScale3D(CapScale);
+    }
+    if (IsValid(VisualizerCapBottom))
+    {
+        VisualizerCapBottom->SetRelativeLocation(CapLocalDown);
+        VisualizerCapBottom->SetRelativeScale3D(CapScale);
+    }
+    if (IsValid(VisualizerShaft))
+    {
+        VisualizerShaft->SetRelativeLocation(FVector::ZeroVector);
+        VisualizerShaft->SetRelativeScale3D(FVector(1.0f, 1.0f, 1.0f));
+    }
+}
+
+void UMjCapsule::ImportFromXml(const FXmlNode* Node)
+{
+    ImportFromXml(Node, FMjCompilerSettings());
+}
+
+void UMjCapsule::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& CompilerSettings)
+{
+    Super::ImportFromXml(Node, CompilerSettings);
+
+    // Super already resolves any `fromto` into pos/quat + Size.Y (half-length).
+    // Capsule's MJCF `size` is [radius, halflength] — same layout as cylinder.
+    Radius     = Size.X;
+    HalfLength = Size.Y;
+
+    // Map (radius, halflength) → parent scale, mirroring UMjCylinder.
+    FVector NewScale;
+    NewScale.X = NewScale.Y = (Radius     * kCmPerM) / kBaseHalf;
+    NewScale.Z              = (HalfLength * kCmPerM) / kBaseHalf;
+    SetRelativeScale3D(NewScale);
+
+    UpdateCapTransforms();
+}
+
+void UMjCapsule::ExportTo(mjsGeom* geom, mjsDefault* def)
+{
+    // Derive radius + half-length back out of the Unreal scale. Base cylinder
+    // is 100cm diameter (radius 50cm) → scale of 1.0 = 50cm radius = 0.5 m.
+    FVector Scale = GetRelativeScale3D();
+    Size.X = Scale.X * 0.5f; // Radius (metres)
+    Size.Y = Scale.Z * 0.5f; // Half-length (metres)
+
+    // User-authored geoms (bWasImported=false) need the size override flag
+    // so the base ExportTo writes both components.
+    if (!bWasImported)
+    {
+        bOverride_Size = true;
+    }
+
+    Super::ExportTo(geom, def);
+}
+
+void UMjCapsule::SyncUnrealTransformFromMj()
+{
+    if (m_GeomView.id == -1) return;
+
+    if (bOverride_FromTo)
+    {
+        // Raw fromto is a two-endpoint description; tearing the composite
+        // down and letting the user author manually is the path of least
+        // surprise (mirrors UMjCylinder's behaviour).
+        auto KillSMC = [](UStaticMeshComponent*& SMC)
+        {
+            if (IsValid(SMC)) { SMC->DestroyComponent(); }
+            SMC = nullptr;
+        };
+        KillSMC(VisualizerShaft);
+        KillSMC(VisualizerCapTop);
+        KillSMC(VisualizerCapBottom);
+        return;
+    }
+
+    if (!bOverride_Size)
+    {
+        const float RadiusVal     = m_GeomView.size[0];
+        const float HalfLengthVal = m_GeomView.size[1];
+
+        const FVector NewScale = FVector(RadiusVal * 2.0f, RadiusVal * 2.0f, HalfLengthVal * 2.0f);
+        SetRelativeScale3D(NewScale);
+
+        UE_LOG(LogURLabBind, Log,
+            TEXT("[MjCapsule] Syncing Scale for '%s' from MuJoCo radius: %f, half-length: %f -> NewScale: %s"),
+            *GetName(), RadiusVal, HalfLengthVal, *NewScale.ToString());
+    }
+
+    UpdateCapTransforms();
+}
+
+#if WITH_EDITOR
+void UMjCapsule::PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent)
+{
+    Super::PostEditChangeProperty(PropertyChangedEvent);
+
+    const FName PropertyName       = (PropertyChangedEvent.Property       != nullptr) ? PropertyChangedEvent.Property->GetFName()       : NAME_None;
+    const FName MemberPropertyName = (PropertyChangedEvent.MemberProperty != nullptr) ? PropertyChangedEvent.MemberProperty->GetFName() : NAME_None;
+
+    // Enforce uniform radius (X==Y) so end caps stay spherical in X/Y.
+    if (PropertyName == FName(TEXT("RelativeScale3D")) || MemberPropertyName == FName(TEXT("RelativeScale3D")))
+    {
+        FVector Scale = GetRelativeScale3D();
+        if (!FMath::IsNearlyEqual(Scale.X, Scale.Y))
+        {
+            Scale.Y = Scale.X;
+            SetRelativeScale3D(Scale);
+        }
+    }
+
+    UpdateCapTransforms();
+}
+#endif
+
+void UMjCapsule::SetGeomVisibility(bool bNewVisibility)
+{
+    auto SetVis = [&](UStaticMeshComponent* SMC)
+    {
+        if (!IsValid(SMC)) return;
+        SMC->SetVisibility(bNewVisibility, false);
+        SMC->bHiddenInGame = !bNewVisibility;
+#if WITH_EDITOR
+        SMC->Modify();
+        SMC->MarkRenderStateDirty();
+        SMC->RecreateRenderState_Concurrent();
+#endif
+    };
+    SetVis(VisualizerShaft);
+    SetVis(VisualizerCapTop);
+    SetVis(VisualizerCapBottom);
+}

--- a/Source/URLab/Public/MuJoCo/Components/Geometry/Primitives/MjCapsule.h
+++ b/Source/URLab/Public/MuJoCo/Components/Geometry/Primitives/MjCapsule.h
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MuJoCo/Components/Geometry/MjGeom.h"
+#include "MjCapsule.generated.h"
+
+/**
+ * @class UMjCapsule
+ * @brief Capsule primitive geometry.
+ *
+ * Unreal doesn't ship `/Engine/BasicShapes/Capsule`, so the visual is
+ * assembled from three engine basic shapes: a shaft cylinder and two sphere
+ * end caps. Sub-mesh transforms are kept in sync with the component's own
+ * relative scale so the gizmo still drives `radius` (X/Y) and `half-length`
+ * (Z) coherently. Caps use a Z-counter-scale so they stay spherical when
+ * the half-length differs from the radius.
+ */
+UCLASS(ClassGroup = (Custom), meta = (BlueprintSpawnableComponent))
+class URLAB_API UMjCapsule : public UMjGeom
+{
+    GENERATED_BODY()
+
+public:
+    UMjCapsule();
+    virtual void OnRegister() override;
+
+    /** @brief Capsule radius. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Primitive")
+    float Radius = 0.0f;
+
+    /** @brief Capsule half-length measured along the component's local Z
+     *         axis. Total axial length from tip-to-tip is `2 * (Radius + HalfLength)`;
+     *         the shaft length (between the cap centres) is `2 * HalfLength`. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Primitive")
+    float HalfLength = 0.0f;
+
+    // UPROPERTY-decorated so Unreal's GC tracks these sub-component pointers.
+    // Editing RelativeScale3D from the Details panel triggers a component
+    // reconstruction; without UPROPERTY, the raw pointers dangle after the
+    // old sub-components are collected, and UpdateCapTransforms crashes with
+    // EXCEPTION_ACCESS_VIOLATION on the stale pointer.
+
+    /** @brief Internal shaft cylinder. */
+    UPROPERTY(Transient)
+    class UStaticMeshComponent* VisualizerShaft = nullptr;
+
+    /** @brief Internal top cap (positive Z). */
+    UPROPERTY(Transient)
+    class UStaticMeshComponent* VisualizerCapTop = nullptr;
+
+    /** @brief Internal bottom cap (negative Z). */
+    UPROPERTY(Transient)
+    class UStaticMeshComponent* VisualizerCapBottom = nullptr;
+
+    virtual void ImportFromXml(const class FXmlNode* Node) override;
+    virtual void ImportFromXml(const class FXmlNode* Node, const struct FMjCompilerSettings& CompilerSettings) override;
+    virtual void ExportTo(mjsGeom* geom, mjsDefault* def = nullptr) override;
+
+    virtual void SyncUnrealTransformFromMj() override;
+    virtual void SetGeomVisibility(bool bNewVisibility) override;
+
+#if WITH_EDITOR
+    virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+#endif
+
+    /** Returns the shaft cylinder so the overlay/debug-viz paths that grep
+     *  for a `UStaticMeshComponent` find *something*. The caps are covered
+     *  by the polymorphic attached-children walk in debug-viz. */
+    virtual class UStaticMeshComponent* GetVisualizerMesh() const override
+    {
+        const_cast<UMjCapsule*>(this)->EnsureVisualizerMesh();
+        return VisualizerShaft;
+    }
+
+    void EnsureVisualizerMesh();
+
+private:
+    /** Position + counter-scale the caps so they sit at the shaft endpoints
+     *  and stay spherical regardless of parent non-uniform scale. */
+    void UpdateCapTransforms();
+};

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -107,6 +107,7 @@
 #include "MuJoCo/Components/Geometry/Primitives/MjBox.h"
 #include "MuJoCo/Components/Geometry/Primitives/MjSphere.h"
 #include "MuJoCo/Components/Geometry/Primitives/MjCylinder.h"
+#include "MuJoCo/Components/Geometry/Primitives/MjCapsule.h"
 #include "MuJoCo/Components/Physics/MjInertial.h"
 #include "MuJoCo/Components/Constraints/MjEquality.h"
 #include "MuJoCo/Components/Keyframes/MjKeyframe.h"
@@ -320,6 +321,7 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
         if (TypeStr == "box") Class = UMjBox::StaticClass();
         else if (TypeStr == "sphere") Class = UMjSphere::StaticClass();
         else if (TypeStr == "cylinder") Class = UMjCylinder::StaticClass();
+        else if (TypeStr == "capsule") Class = UMjCapsule::StaticClass();
 
         CreatedNode = BP->SimpleConstructionScript->CreateNode(Class, *Name);
         UMjGeom* GeomComp = Cast<UMjGeom>(CreatedNode->ComponentTemplate);

--- a/Source/URLabEditor/Private/Tests/MjCapsuleTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjCapsuleTests.cpp
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "Tests/MjTestHelpers.h"
+#include "MuJoCo/Components/Geometry/Primitives/MjCapsule.h"
+#include "mujoco/mujoco.h"
+
+// ============================================================================
+// URLab.Capsule.Import_SizeForm_CreatesUMjCapsule
+//   <geom type="capsule" size="radius halflength"> → UMjCapsule with matching
+//   Radius/HalfLength and parent scale set to cm-convention (X=Y=2R, Z=2H).
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCapsuleImportSizeForm,
+    "URLab.Capsule.Import_SizeForm_CreatesUMjCapsule",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCapsuleImportSizeForm::RunTest(const FString& Parameters)
+{
+    const TCHAR* Xml = TEXT(R"(<mujoco>
+  <worldbody>
+    <body name="arm" pos="0 0 1">
+      <geom name="upper" type="capsule" size="0.05 0.15" pos="0 0 0"/>
+      <joint name="j" type="hinge" axis="0 1 0"/>
+    </body>
+  </worldbody>
+</mujoco>)");
+
+    FMjXmlImportSession S;
+    if (!S.Init(Xml))
+    {
+        AddError(FString::Printf(TEXT("Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjCapsule* Cap = S.FindTemplate<UMjCapsule>(TEXT("upper"));
+    if (!TestNotNull(TEXT("UMjCapsule 'upper'"), Cap)) return false;
+
+    TestEqual(TEXT("Radius"),     Cap->Radius,     0.05f);
+    TestEqual(TEXT("HalfLength"), Cap->HalfLength, 0.15f);
+
+    // Parent scale should map radius → 2R (cm-to-UE), halflength → 2H.
+    const FVector Scale = Cap->GetRelativeScale3D();
+    TestTrue(TEXT("Scale.X ≈ 0.1"), FMath::IsNearlyEqual(Scale.X, 0.1f, 1e-4f));
+    TestTrue(TEXT("Scale.Y ≈ 0.1"), FMath::IsNearlyEqual(Scale.Y, 0.1f, 1e-4f));
+    TestTrue(TEXT("Scale.Z ≈ 0.3"), FMath::IsNearlyEqual(Scale.Z, 0.3f, 1e-4f));
+
+    return true;
+}
+
+// ============================================================================
+// URLab.Capsule.Import_FromToForm_ResolvedByBase
+//   <geom type="capsule" fromto="...">. Base UMjGeom resolves fromto into
+//   pos/quat/size[1]; the capsule subclass just reads the resolved values.
+//   HalfLength should equal |B-A| / 2.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCapsuleImportFromTo,
+    "URLab.Capsule.Import_FromToForm_ResolvedByBase",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCapsuleImportFromTo::RunTest(const FString& Parameters)
+{
+    // Endpoints 0.3 m apart along +Z → halflength 0.15 m. Radius from size[0].
+    const TCHAR* Xml = TEXT(R"(<mujoco>
+  <worldbody>
+    <body name="arm" pos="0 0 1">
+      <geom name="upper" type="capsule" size="0.05" fromto="0 0 -0.15 0 0 0.15"/>
+      <joint name="j" type="hinge" axis="0 1 0"/>
+    </body>
+  </worldbody>
+</mujoco>)");
+
+    FMjXmlImportSession S;
+    if (!S.Init(Xml))
+    {
+        AddError(FString::Printf(TEXT("Init failed: %s"), *S.LastError));
+        return false;
+    }
+
+    UMjCapsule* Cap = S.FindTemplate<UMjCapsule>(TEXT("upper"));
+    if (!TestNotNull(TEXT("UMjCapsule 'upper'"), Cap)) return false;
+
+    TestEqual(TEXT("Radius (from size)"),       Cap->Radius,     0.05f);
+    TestTrue (TEXT("HalfLength resolved to ~0.15"),
+              FMath::IsNearlyEqual(Cap->HalfLength, 0.15f, 1e-4f));
+    return true;
+}
+
+// ============================================================================
+// URLab.Capsule.Compile_ProducesCapsuleGeom
+//   A compiled model should report geom type mjGEOM_CAPSULE, the intended
+//   radius, and matching half-length, proving we're round-tripping the shape
+//   through the URLab pipeline rather than silently dropping it.
+// ============================================================================
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjCapsuleCompile,
+    "URLab.Capsule.Compile_ProducesCapsuleGeom",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+
+bool FMjCapsuleCompile::RunTest(const FString& Parameters)
+{
+    const TCHAR* Xml = TEXT(R"(<mujoco>
+  <worldbody>
+    <body name="arm" pos="0 0 1">
+      <geom name="upper" type="capsule" size="0.05 0.15"/>
+      <joint name="j" type="hinge" axis="0 1 0"/>
+    </body>
+  </worldbody>
+</mujoco>)");
+
+    FMjXmlImportSession S;
+    if (!S.Init(Xml))        { AddError(S.LastError); return false; }
+    if (!S.Compile())        { AddError(S.LastError); return false; }
+
+    const mjModel* M = S.Model();
+    if (!TestNotNull(TEXT("compiled model"), (void*)M)) return false;
+
+    // Locate the capsule geom — the plugin may prefix names with the actor.
+    int GeomId = -1;
+    for (int i = 0; i < M->ngeom; ++i)
+    {
+        if (M->geom_type[i] == mjGEOM_CAPSULE) { GeomId = i; break; }
+    }
+    if (!TestTrue(TEXT("capsule geom present in model"), GeomId >= 0))
+    {
+        return false;
+    }
+
+    TestTrue(TEXT("radius ≈ 0.05"),
+        FMath::IsNearlyEqual((float)M->geom_size[GeomId * 3 + 0], 0.05f, 1e-4f));
+    TestTrue(TEXT("halflength ≈ 0.15"),
+        FMath::IsNearlyEqual((float)M->geom_size[GeomId * 3 + 1], 0.15f, 1e-4f));
+    return true;
+}

--- a/docs/mjcf_schema_coverage.md
+++ b/docs/mjcf_schema_coverage.md
@@ -76,7 +76,7 @@ Plugin version: UnrealRoboticsLab main branch, 2026-04-18
 |-----------|--------|-------|
 | name | SUPPORTED | Import: `GetAttribute("name")`. Export: `SetSpecElementName` |
 | class | SUPPORTED | Import: `ReadAttrString("class")`. Export: `ResolveDefault` |
-| type | SUPPORTED | Import: string -> enum (plane/hfield/sphere/capsule/ellipsoid/cylinder/box/mesh/sdf). Export: writes `Geom->type` |
+| type | SUPPORTED | Import: string -> enum (plane/hfield/sphere/capsule/ellipsoid/cylinder/box/mesh/sdf). Export: writes `Geom->type`. Primitives with a dedicated UE visualizer class: box (`UMjBox`), sphere (`UMjSphere`), cylinder (`UMjCylinder`), capsule (`UMjCapsule`, composite of engine cylinder + two sphere caps). Other types (ellipsoid, plane, hfield, sdf) use the base `UMjGeom` without a visualizer mesh. |
 | contype | SUPPORTED | Import: `ReadAttrInt`. Export: `Geom->contype` |
 | conaffinity | SUPPORTED | Import: `ReadAttrInt`. Export: `Geom->conaffinity` |
 | condim | SUPPORTED | Import: `ReadAttrInt`. Export: `Geom->condim` |


### PR DESCRIPTION
## Summary

- Add `UMjCapsule` geometry primitive. Composes the capsule out of an engine cylinder shaft plus two sphere end caps, with cap positions and scales derived from the component's own relative scale so the standard UE gizmo drives radius (X/Y) and half-length (Z) coherently. The Z counter-scale on the caps keeps them spherical when halflength differs from radius.
- Harden sub-mesh pointers: `UPROPERTY(Transient)` + `IsValid`-guarded so editor scaling (which triggers component reconstruction) doesn't dangle pointers.
- Wire the importer: `MujocoXmlParser` now dispatches `<geom type="capsule">` to `UMjCapsule`. `fromto` resolution is inherited from the base `UMjGeom` path.
- Three new automation tests: size-form import, fromto-form resolution, and a compile-through check that the capsule lands as a capsule geom in `mjModel`.

## Motivation

Capsule is one of the most common primitive types in robot MJCFs (limbs, fingers, torso) but URLab was falling back to a mesh import. A first-class primitive means authors can edit radius/length directly in the Details panel, the viewport gizmo works as expected, and the visual/collision shape stays perfectly in sync without round-tripping through a mesh asset.

## Linked issue

Related to roadmap item "primitive geometry coverage".

## Proof of compilation

\`\`\`
[11/14] Link [x64] UnrealEditor-URLab.lib
[12/14] Link [x64] UnrealEditor-URLabEditor.dll
[13/14] Link [x64] UnrealEditor-URLab.dll
[14/14] WriteMetadata url_projEditor.target [NoUba]

Trace written to file C:/Users/jonat/AppData/Local/UnrealBuildTool/Log.uba with size 7.2kb
Total time in Unreal Build Accelerator local executor: 21.60 seconds

Result: Succeeded
Total execution time: 29.87 seconds
\`\`\`

## Test evidence

\`\`\`
$ PASS=$(grep -cE 'Result=\{Success\}' /tmp/urlab_test.log)
$ FAIL=$(grep -cE 'Result=\{(Fail|Error)\}' /tmp/urlab_test.log)
$ echo "Passed: \$PASS / \$((PASS+FAIL))"
Passed: 167 / 167
$ echo "Failed: \$FAIL"
Failed: 0
$ grep -iE "tests performed" /tmp/urlab_test.log
...Automation Test Queue Empty 167 tests performed.
\`\`\`

(Three new tests land with this PR: `MjCapsuleTests` — size-form import, fromto resolution, compile-through — hence the count rises from 164 → 167 compared to the pre-capsule baseline.)

## Manual verification steps

1. In PIE or the articulation editor, import an MJCF snippet containing a capsule in either form:
   \`\`\`xml
   <geom type="capsule" size="0.05 0.15"/>
   <geom type="capsule" fromto="0 0 0  0 0 0.3" size="0.05"/>
   \`\`\`
2. Expect a `UMjCapsule` component on the articulation with the correct visual (shaft + two spherical caps).
3. In the Details panel, change the component's **Scale** — X/Y should resize radius, Z should resize half-length. The caps should stay spherical regardless of the Z scale.
4. Toggle the collision wireframe overlay (\`3\` for articulations, \`5\` for Quick-Convert). The wireframe should match the visual envelope exactly.
5. Drop a couple of capsules into a scene with gravity — they should roll on their sides and rock end-to-end like a pill, not a cylinder.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full \`URLab.*\` automation suite passes (167 / 167)
- [x] Docs updated for user-facing changes (\`docs/mjcf_schema_coverage.md\`)