### PR TITLE
Add build_and_test helper scripts with summary-block PR workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,28 +16,38 @@ and the full URLab automation suite passes on your machine.
 
 Fixes #  /  Related to #
 
-## Proof of compilation
+## Build + test evidence
 
 <!--
-Paste the tail of your UnrealBuildTool / Build.bat output, enough to show
-"Result: Succeeded". MuJoCo ASAN_* macro-redefinition warnings are expected
-and can stay in the snippet.
+Run the helper script from the plugin root and paste its final summary
+block below — it captures the build status, pass/total test counts, the
+git HEAD the run was made from, and a SHA-256 of the log so the run can
+be verified against the attached log if needed.
+
+bash (git-bash, WSL):
+  ./Scripts/build_and_test.sh \
+      --engine "/c/Program Files/Epic Games/UE_5.7" \
+      --project "C:/path/to/your.uproject"
+
+PowerShell:
+  .\Scripts\build_and_test.ps1 `
+      -Engine  'C:\Program Files\Epic Games\UE_5.7' `
+      -Project 'C:\path\to\your.uproject'
+
+Close the Unreal editor before running — live-coding holds the build
+mutex and the cmd-line tester silently returns an empty log.
 -->
 
 ```
-```
-
-## Test evidence
-
-<!--
-Paste the tail of the URLab automation run. We're looking for the pass
-count and any failures, e.g.
-  grep -cE "Result=\{Success\}" ...
-  159
-  (no failures)
--->
-
-```
+=== URLab build+test summary ===
+Timestamp : <UTC>
+Host      : <machine>
+Git HEAD  : <short-sha> (<branch>)
+Engine    : <engine root>
+Build     : <Succeeded|Failed>
+Tests     : <pass> / <total> passed (<fail> failed)
+Log       : <path>  (sha256: <hash>)
+================================
 ```
 
 ## Manual verification steps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,20 +21,28 @@ Thank you for your interest in contributing. This document covers the process fo
    - UPROPERTYs use PascalCase (`Options`, `SimSpeedPercent`)
    - Non-UPROPERTY private members use `m_` prefix (`m_model`, `m_data`)
    - All `.h` and `.cpp` files must have the Apache 2.0 license header
-3. Build and verify compilation succeeds.
-4. Run the URLab automation suite. Two options:
-   - Session Frontend in the Unreal Editor, or
-   - Command line:
-     ```
-     UnrealEditor-Cmd.exe YourProject.uproject -ExecCmds="Automation RunTests URLab;Quit" -Unattended -NullRHI -Log
-     ```
-     The command-line form gives you output you can paste straight into the PR template.
-5. Test your changes in PIE (Play in Editor).
+3. Build and verify compilation succeeds, then run the URLab automation suite. The `Scripts/build_and_test.{sh,ps1}` helpers do both in one shot and print a summary block you paste straight into the PR template — with a UTC timestamp, your git HEAD, build status, `passed / total` counts, and a SHA-256 of the full test log. **Close the Unreal editor first** — live-coding holds the build mutex and the test runner silently returns an empty log against a locked project.
+
+   Git-bash / WSL:
+   ```bash
+   ./Scripts/build_and_test.sh \
+       --engine "/c/Program Files/Epic Games/UE_5.7" \
+       --project "C:/path/to/your.uproject"
+   ```
+   PowerShell:
+   ```powershell
+   .\Scripts\build_and_test.ps1 `
+       -Engine  'C:\Program Files\Epic Games\UE_5.7' `
+       -Project 'C:\path\to\your.uproject'
+   ```
+
+   Prefer that flow. If you only need to re-run a single step you can invoke `UnrealEditor-Cmd.exe` or `UnrealBuildTool.exe` directly — see the script source for the canonical flags. You can also run individual tests from the Session Frontend inside the editor.
+4. Test your changes in PIE (Play in Editor).
 
 ## Submitting a Pull Request
 
 1. Push to your fork and open a PR against `main`.
-2. Fill in the [PR template](.github/pull_request_template.md). It asks for a summary, motivation, linked issue, **proof that the project builds**, and **proof that the `URLab.*` automation suite passes** on your machine — paste the tail of each command's output into the provided blocks.
+2. Fill in the [PR template](.github/pull_request_template.md). It asks for a summary, motivation, linked issue, and the **build+test summary block** produced by `Scripts/build_and_test.{sh,ps1}` (see step 3 above). That block is the primary gate.
 3. We spot-check every PR in the editor before merging, but because Unreal Engine projects can't use standard CI the pasted build + test output is the primary gate. A PR without them will bounce back for that evidence.
 
 ## Code Style

--- a/Scripts/build_and_test.ps1
+++ b/Scripts/build_and_test.ps1
@@ -1,0 +1,118 @@
+# Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# --- LEGAL DISCLAIMER ---
+# UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+# endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+# trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+#
+# This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+# CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+<#
+.SYNOPSIS
+    Build url_projEditor and run the URLab automation suite, then print a
+    machine-identifiable summary block to paste into a PR.
+
+.EXAMPLE
+    .\Scripts\build_and_test.ps1 `
+        -Engine  'C:\Program Files\Epic Games\UE_5.7' `
+        -Project 'C:\path\to\your.uproject'
+
+.NOTES
+    Exit codes: 0 ok, 1 build failed, 2 tests failed, 3 bad args.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $Engine,
+    [Parameter(Mandatory = $true)] [string] $Project,
+    [string] $Target = 'url_projEditor',
+    [string] $Filter = 'URLab',
+    [string] $Log    = (Join-Path $env:TEMP 'urlab_test.log')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$ubt = Join-Path $Engine 'Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe'
+$cmd = Join-Path $Engine 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
+
+if (-not (Test-Path $ubt)) { Write-Error "UBT not found: $ubt";                exit 3 }
+if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   exit 3 }
+
+# --- Build -----------------------------------------------------------------
+Write-Host ">>> Building $Target (Win64 Development)..."
+$buildArgs = @($Target, 'Win64', 'Development', "-Project=$Project", '-WaitMutex')
+$buildOut  = & $ubt @buildArgs 2>&1
+$buildOut | Select-Object -Last 10 | ForEach-Object { Write-Host $_ }
+$buildStatus = if ($buildOut -match 'Result: Succeeded') { 'Succeeded' } else { 'Failed' }
+
+# --- Test ------------------------------------------------------------------
+$pass  = 0
+$fail  = 0
+$total = 0
+$testsPerformed = ''
+
+if ($buildStatus -eq 'Succeeded') {
+    Write-Host ">>> Running automation tests (filter=$Filter, log=$Log)..."
+    $testArgs = @(
+        $Project,
+        "-ExecCmds=Automation RunTests $Filter",
+        '-Unattended', '-NullRHI', '-NoSound', '-NoSplash', '-stdout', '-log',
+        '-TestExit=Automation Test Queue Empty'
+    )
+    & $cmd @testArgs *> $Log
+
+    if (-not (Test-Path $Log) -or (Get-Item $Log).Length -eq 0) {
+        Write-Error "Test log is empty - editor likely held the project lock."
+    }
+    else {
+        $content = Get-Content $Log -Raw
+        $pass  = ([regex]::Matches($content, 'Result=\{Success\}')).Count
+        $fail  = ([regex]::Matches($content, 'Result=\{(Fail|Error)\}')).Count
+        $total = $pass + $fail
+        if ($content -match '(\d+) tests performed') { $testsPerformed = $Matches[1] + ' tests performed' }
+    }
+}
+
+# --- Fingerprint + summary -------------------------------------------------
+$ts        = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss') + ' UTC'
+$hostName  = [System.Net.Dns]::GetHostName()
+try {
+    $gitSha    = (git rev-parse --short=8 HEAD 2>$null).Trim()
+    $gitBranch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim()
+} catch { $gitSha = 'unknown'; $gitBranch = 'unknown' }
+
+$logHash = 'n/a'
+if ((Test-Path $Log) -and (Get-Item $Log).Length -gt 0) {
+    $logHash = (Get-FileHash $Log -Algorithm SHA256).Hash.Substring(0, 16).ToLowerInvariant()
+}
+
+$testsLine = '{0} / {1} passed ({2} failed)' -f $pass, $total, $fail
+if ($testsPerformed) { $testsLine += '  [' + $testsPerformed + ']' }
+
+Write-Host ''
+Write-Host '=== URLab build+test summary ==='
+Write-Host ('Timestamp : ' + $ts)
+Write-Host ('Host      : ' + $hostName)
+Write-Host ('Git HEAD  : {0} ({1})' -f $gitSha, $gitBranch)
+Write-Host ('Engine    : ' + $Engine)
+Write-Host ('Build     : ' + $buildStatus)
+Write-Host ('Tests     : ' + $testsLine)
+Write-Host ('Log       : {0}  (sha256: {1})' -f $Log, $logHash)
+Write-Host '================================'
+
+if ($buildStatus -ne 'Succeeded') { exit 1 }
+if ($fail -gt 0 -or $total -eq 0) { exit 2 }
+exit 0

--- a/Scripts/build_and_test.sh
+++ b/Scripts/build_and_test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# --- LEGAL DISCLAIMER ---
+# UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+# endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+# trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+#
+# This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+# CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+# build_and_test.sh — build url_projEditor and run the URLab automation suite,
+# then print a machine-identifiable summary block to paste into a PR.
+#
+# Usage:
+#   ./Scripts/build_and_test.sh \
+#       --engine "/c/Program Files/Epic Games/UE_5.7" \
+#       --project "C:/path/to/your.uproject" \
+#       [--target url_projEditor] \
+#       [--filter URLab] \
+#       [--log /tmp/urlab_test.log]
+#
+# Exit codes: 0 ok, 1 build failed, 2 tests failed, 3 bad args.
+
+set -eu
+
+TARGET="url_projEditor"
+FILTER="URLab"
+LOG="/tmp/urlab_test.log"
+ENGINE=""
+PROJECT=""
+
+usage() {
+    cat >&2 <<'HELP'
+build_and_test.sh — build url_projEditor and run the URLab automation suite.
+
+Usage:
+  ./Scripts/build_and_test.sh \
+      --engine "/c/Program Files/Epic Games/UE_5.7" \
+      --project "C:/path/to/your.uproject" \
+      [--target url_projEditor] \
+      [--filter URLab] \
+      [--log /tmp/urlab_test.log]
+
+Exit codes: 0 ok, 1 build failed, 2 tests failed, 3 bad args.
+HELP
+    exit 3
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --engine)   ENGINE="$2";  shift 2 ;;
+        --project)  PROJECT="$2"; shift 2 ;;
+        --target)   TARGET="$2";  shift 2 ;;
+        --filter)   FILTER="$2";  shift 2 ;;
+        --log)      LOG="$2";     shift 2 ;;
+        -h|--help)  usage ;;
+        *) echo "Unknown arg: $1" >&2; usage ;;
+    esac
+done
+
+[[ -z "$ENGINE"  ]] && { echo "Missing --engine"  >&2; usage; }
+[[ -z "$PROJECT" ]] && { echo "Missing --project" >&2; usage; }
+
+UBT="$ENGINE/Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.exe"
+CMD="$ENGINE/Engine/Binaries/Win64/UnrealEditor-Cmd.exe"
+
+[[ -x "$UBT" ]] || { echo "UBT not found: $UBT" >&2; exit 3; }
+[[ -x "$CMD" ]] || { echo "UnrealEditor-Cmd not found: $CMD" >&2; exit 3; }
+
+# --- Build -----------------------------------------------------------------
+echo ">>> Building $TARGET (Win64 Development)..."
+BUILD_OUT=$("$UBT" "$TARGET" Win64 Development "-Project=$PROJECT" -WaitMutex 2>&1 || true)
+echo "$BUILD_OUT" | tail -10
+if echo "$BUILD_OUT" | grep -q "Result: Succeeded"; then
+    BUILD_STATUS="Succeeded"
+else
+    BUILD_STATUS="Failed"
+fi
+
+# --- Test ------------------------------------------------------------------
+PASS=0
+FAIL=0
+TOTAL=0
+TESTS_PERFORMED_LINE=""
+
+if [[ "$BUILD_STATUS" == "Succeeded" ]]; then
+    echo ">>> Running automation tests (filter=$FILTER, log=$LOG)..."
+    "$CMD" "$PROJECT" \
+        -ExecCmds="Automation RunTests $FILTER" \
+        -Unattended -NullRHI -NoSound -NoSplash -stdout -log \
+        -TestExit="Automation Test Queue Empty" \
+        > "$LOG" 2>&1 || true
+
+    if [[ ! -s "$LOG" ]]; then
+        echo "ERROR: test log is empty — editor likely held the project lock." >&2
+    fi
+
+    PASS=$(grep -cE 'Result=\{Success\}' "$LOG" || true)
+    FAIL=$(grep -cE 'Result=\{(Fail|Error)\}' "$LOG" || true)
+    TOTAL=$((PASS + FAIL))
+    TESTS_PERFORMED_LINE=$(grep -oE '[0-9]+ tests performed' "$LOG" | tail -1 || true)
+fi
+
+# --- Fingerprint + summary -------------------------------------------------
+TS=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+HOST=$(hostname 2>/dev/null || echo "unknown")
+GIT_SHA=$(git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+LOG_HASH="n/a"
+if [[ -s "$LOG" ]]; then
+    if command -v sha256sum >/dev/null 2>&1; then
+        LOG_HASH=$(sha256sum "$LOG" | cut -c1-16)
+    elif command -v shasum >/dev/null 2>&1; then
+        LOG_HASH=$(shasum -a 256 "$LOG" | cut -c1-16)
+    fi
+fi
+
+cat <<EOF
+
+=== URLab build+test summary ===
+Timestamp : $TS
+Host      : $HOST
+Git HEAD  : $GIT_SHA ($GIT_BRANCH)
+Engine    : $ENGINE
+Build     : $BUILD_STATUS
+Tests     : $PASS / $TOTAL passed ($FAIL failed)${TESTS_PERFORMED_LINE:+  [$TESTS_PERFORMED_LINE]}
+Log       : $LOG  (sha256: $LOG_HASH)
+================================
+EOF
+
+[[ "$BUILD_STATUS" != "Succeeded" ]] && exit 1
+[[ "$FAIL" -gt 0 || "$TOTAL" -eq 0 ]] && exit 2
+exit 0


### PR DESCRIPTION
## Summary

- New `Scripts/build_and_test.sh` (git-bash / WSL) and `Scripts/build_and_test.ps1` (PowerShell) that build `url_projEditor` and run the full `URLab.*` automation suite end-to-end, then print a structured summary block with UTC timestamp, host, git HEAD short-SHA + branch, build status, `passed / total` test counts, and a SHA-256 of the full test log.
- `.github/pull_request_template.md` now asks for that summary block instead of raw command-output tails.
- `CONTRIBUTING.md` updated to point at the script as the standard workflow.
- Both scripts take `--engine`, `--project`, `--target`, `--filter`, `--log` CLI flags so they work for forks / non-default layouts.

## Motivation

Unreal Engine projects can't run on standard CI runners, so every PR has to ship proof that the submitter built and ran the suite locally. Pasting raw UBT / `UnrealEditor-Cmd` output is noisy and trivial to fake. A one-shot helper that emits a structured block — one the reviewer can cross-reference against the branch tip and, if ever doubted, against the actual log file via the hash — keeps evidence cheap to produce and expensive to forge. It also guards against the silent-failure mode where the editor is open and `UnrealEditor-Cmd` returns an empty log against a locked project.

## Linked issue

None — workflow hardening.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-19 16:57:38 UTC
Host      : buzz-main
Git HEAD  : 7b174be7 (chore/build-test-scripts)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 164 / 164 passed (0 failed)  [164 tests performed]
Log       : /tmp/urlab_test.log  (sha256: afe52f2156b2e761)
================================
```

(Generated by running the new `Scripts/build_and_test.sh` against this branch's tip — dogfooded. Counts match the pre-capsule baseline since this branch is off `main`.)

## Manual verification steps

1. From the plugin root, run the bash version:
   \`\`\`bash
   ./Scripts/build_and_test.sh        --engine "/c/Program Files/Epic Games/UE_5.7"        --project "C:/path/to/your.uproject"
   \`\`\`
   Expect a build log tail, then a test run, then the summary block. Exit code 0 on clean pass, 1 on build fail, 2 on any test fail.
2. Re-run with the PowerShell version:
   \`\`\`powershell
   .\Scripts\build_and_test.ps1 `
       -Engine  'C:\Program Files\Epic Games\UE_5.7' `
       -Project 'C:\path\to\your.uproject'
   \`\`\`
   Summary block should match the bash version structurally (paths + hashes differ — timestamps + the log itself change every run, which is why the SHA-256 is per-run).
3. Start the Unreal editor in the background (with live-coding), re-run the script, and confirm it prints the "test log is empty - editor likely held the project lock" guard rather than a bogus 0 / 0 pass line.
4. Try `./Scripts/build_and_test.sh --help` — expect a usage block.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full \`URLab.*\` automation suite passes (164 / 164)
- [x] Docs updated for user-facing changes (\`CONTRIBUTING.md\`, PR template)