### PR TITLE
Dedup URLab.Import.MJ_Autolimits test + fix against MuJoCo 3.x default

### DIFF
--- a/Source/URLabEditor/Private/Tests/MjImportTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjImportTests.cpp
@@ -144,32 +144,6 @@ bool FTest_MjImport_MJ_JointRange::RunTest(const FString&)
     return true;
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjImport_MJ_Autolimits,
-    "URLab.Import.MJ_Autolimits",
-    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
-bool FTest_MjImport_MJ_Autolimits::RunTest(const FString&)
-{
-    // autolimits=true — a non-empty range implies limited=true without explicit attribute
-    FMjTestSession S;
-    if (!S.CompileXml(TEXT(R"(
-        <mujoco>
-          <compiler autolimits="true"/>
-          <worldbody>
-            <body>
-              <joint name="j1" type="hinge" range="-1.57 1.57"/>
-              <geom size=".1"/>
-            </body>
-          </worldbody>
-        </mujoco>
-    )"))) { AddError(S.LastError); return false; }
-
-    int jid = S.JointId("j1");
-    TestTrue(TEXT("j1 valid"), jid >= 0);
-    TestTrue(TEXT("j1 limited via autolimits"), S.m->jnt_limited[jid] != 0);
-    S.Cleanup();
-    return true;
-}
-
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjImport_MJ_DefaultClassOverride,
     "URLab.Import.MJ_DefaultClassOverride",
     EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
@@ -952,18 +926,17 @@ bool FTest_MjImport_MJ_MocapBody::RunTest(const FString&)
 
 // =============================================================================
 // URLab.Import.MJ_AutoLimits
-//   <compiler autolimits="true"/> makes any joint with a range= attribute
-//   automatically limited without needing limited="true".
-//   Tier 1 baseline: verifies MuJoCo's own behaviour.
+//   MuJoCo 3.x defaults autolimits="true" — a joint with range= is auto-limited.
+//   Explicit limited="false" opts out.
 // =============================================================================
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjImport_MJ_AutoLimits,
     "URLab.Import.MJ_AutoLimits",
     EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
 bool FTest_MjImport_MJ_AutoLimits::RunTest(const FString&)
 {
-    // Without autolimits: range present but limited not set → joint NOT limited
-    FMjTestSession SNo;
-    if (!SNo.CompileXml(TEXT(R"(
+    // Default autolimits: range present → joint IS limited
+    FMjTestSession SAuto;
+    if (!SAuto.CompileXml(TEXT(R"(
         <mujoco>
           <compiler angle="radian"/>
           <worldbody>
@@ -973,31 +946,31 @@ bool FTest_MjImport_MJ_AutoLimits::RunTest(const FString&)
             </body>
           </worldbody>
         </mujoco>
-    )"))) { AddError(SNo.LastError); return false; }
-    int jid = SNo.JointId("j1");
-    TestTrue(TEXT("j1 valid without autolimits"), jid >= 0);
+    )"))) { AddError(SAuto.LastError); return false; }
+    int jid = SAuto.JointId("j1");
+    TestTrue(TEXT("j1 valid"), jid >= 0);
     if (jid >= 0)
-        TestTrue(TEXT("j1 NOT limited without autolimits"), SNo.m->jnt_limited[jid] == 0);
-    SNo.Cleanup();
+        TestTrue(TEXT("j1 IS limited by default autolimits"), SAuto.m->jnt_limited[jid] == 1);
+    SAuto.Cleanup();
 
-    // With autolimits: range present → joint IS limited
-    FMjTestSession SYes;
-    if (!SYes.CompileXml(TEXT(R"(
+    // Explicit limited="false" overrides autolimits → joint NOT limited
+    FMjTestSession SOverride;
+    if (!SOverride.CompileXml(TEXT(R"(
         <mujoco>
-          <compiler angle="radian" autolimits="true"/>
+          <compiler angle="radian"/>
           <worldbody>
             <body>
-              <joint name="j2" type="hinge" range="-1 1"/>
+              <joint name="j2" type="hinge" range="-1 1" limited="false"/>
               <geom size=".1"/>
             </body>
           </worldbody>
         </mujoco>
-    )"))) { AddError(SYes.LastError); return false; }
-    int jid2 = SYes.JointId("j2");
-    TestTrue(TEXT("j2 valid with autolimits"), jid2 >= 0);
+    )"))) { AddError(SOverride.LastError); return false; }
+    int jid2 = SOverride.JointId("j2");
+    TestTrue(TEXT("j2 valid"), jid2 >= 0);
     if (jid2 >= 0)
-        TestTrue(TEXT("j2 IS limited with autolimits"), SYes.m->jnt_limited[jid2] == 1);
-    SYes.Cleanup();
+        TestTrue(TEXT("j2 NOT limited via explicit limited=false"), SOverride.m->jnt_limited[jid2] == 0);
+    SOverride.Cleanup();
     return true;
 }
 


### PR DESCRIPTION
## Summary

- Remove `URLab.Import.MJ_Autolimits` (the stub) in `MjImportTests.cpp`. Its name collides case-insensitively with the superset `URLab.Import.MJ_AutoLimits` further down the file; UE's automation-test registry can only hold one of the two, which made the `URLab.*` suite intermittently fail the losing name with no class behind it.
- Bring the remaining `MJ_AutoLimits` up to MuJoCo 3.x semantics. 3.x defaults `autolimits="true"`, so the original test's "without autolimits ⇒ NOT limited" branch is no longer meaningful (and `autolimits="false"` + bare `range=` is now a hard compile error). Replace it with the still-valid opt-out path: `limited="false"` overrides `autolimits`, yielding an unlimited joint.

## Motivation

The collision has been latent since `8f571e7` (initial release). It surfaced now because the failing test is non-deterministic across link orders, and rebases of stacked branches were the scenario that flipped which registration won. Once the assertion started firing, it also exposed that the test was written against pre-3.x MuJoCo behaviour. Fixing both in one go clears the flake at the root and keeps the test semantically useful.

## Linked issue

None — latent bug surfaced during rebase of #14.

## Verification of the compiler change

Reproduced locally with the `mj` Python env:

```
mujoco 3.5.0
<compiler angle="radian"/> + range=-1 1           → jnt_limited = 1
<joint ... range="-1 1" limited="false"/>         → jnt_limited = 0
<compiler autolimits="false"/> + bare range       → "joint has `range` but not `limited`" compile error
```

Matches the assertions the updated test is making.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-19 17:28:40 UTC
Host      : buzz-main
Git HEAD  : b1a8061b (fix/dedup-autolimits-test)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 174 / 174 passed (0 failed)  [174 tests performed]
Log       : /tmp/urlab_test.log  (sha256: 332de48e55c5529f)
================================
```

(Test count unchanged from main — one registration disappears because the collision is gone, the other — `MJ_AutoLimits` — was already counted.)

## Manual verification steps

1. From the plugin root on this branch, run `./Scripts/build_and_test.sh --engine ... --project ...` (or the `.ps1` equivalent) and confirm `174 / 174 passed`, no `Failed to register test with the name` warning in the log.
2. `grep -n 'MJ_Autolimits\|MJ_AutoLimits' Source/URLabEditor/Private/Tests/MjImportTests.cpp` — expect the stub (lines ~147-171 on main) to be gone, and a single `MJ_AutoLimits` test remaining.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes (174 / 174)
- [x] Docs updated for user-facing changes (n/a — test-only change)