### PR TITLE
Fix default-class joint ranges under angle="radian" (menagerie-wide joint-motion regression)

### DIFF
--- a/Source/URLabEditor/Private/MujocoGenerationAction.cpp
+++ b/Source/URLabEditor/Private/MujocoGenerationAction.cpp
@@ -170,20 +170,22 @@ void UMujocoGenerationAction::GenerateForBlueprintXml(UBlueprint* BP, const FStr
     USCS_Node* EqualitiesNode  = Hierarchy.EqualitiesRoot;
     USCS_Node* KeyframesNode   = Hierarchy.KeyframesRoot;
 
-    // 2. Pass: Defaults
-    ParseDefaultsRecursive(Root, BP, DefaultsNode, XMLDir, TEXT(""));
+    // 2. Parse compiler settings first (angle, eulerseq) so they can be
+    //    propagated into <default>-block imports — joint ranges inside a
+    //    default class depend on the compiler-level `angle` setting.
+    FMjCompilerSettings CompilerSettings = MjOrientationUtils::ParseCompilerSettings(Root);
 
-    // 2a. Pass: Contact pairs and excludes
+    // 2a. Pass: Defaults
+    ParseDefaultsRecursive(Root, BP, DefaultsNode, XMLDir, CompilerSettings, TEXT(""));
+
+    // 2b. Pass: Contact pairs and excludes
     ParseContactSection(Root, BP, ContactsNode, XMLDir);
 
-    // 2b. Pass: Equality constraints
+    // 2c. Pass: Equality constraints
     ParseEqualitySection(Root, BP, EqualitiesNode, XMLDir);
 
-    // 2c. Pass: Keyframes
+    // 2d. Pass: Keyframes
     ParseKeyframeSection(Root, BP, KeyframesNode, XMLDir);
-
-    // 2d. Parse compiler settings (angle, eulerseq) for orientation handling
-    FMjCompilerSettings CompilerSettings = MjOrientationUtils::ParseCompilerSettings(Root);
 
     // 3. Pass: Structure Traversal
     USCS_Node* WorldBodyNode = nullptr;

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -1131,7 +1131,7 @@ void UMujocoGenerationAction::ParseAssetsRecursive(const FXmlNode* Node, const F
     }
 }
 
-void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlueprint* BP, USCS_Node* RootNode, const FString& XMLDir, const FString& ParentClassName, bool bIsDefaultContext)
+void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlueprint* BP, USCS_Node* RootNode, const FString& XMLDir, const FMjCompilerSettings& CompilerSettings, const FString& ParentClassName, bool bIsDefaultContext)
 {
     if (!Node || !BP || !RootNode) return;
 
@@ -1147,7 +1147,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
              FXmlFile IncludedFile(IncludePath);
              if (IncludedFile.IsValid())
              {
-                 ParseDefaultsRecursive(IncludedFile.GetRootNode(), BP, RootNode, FPaths::GetPath(IncludePath), ParentClassName, bIsDefaultContext);
+                 ParseDefaultsRecursive(IncludedFile.GetRootNode(), BP, RootNode, FPaths::GetPath(IncludePath), CompilerSettings, ParentClassName, bIsDefaultContext);
              }
         }
     }
@@ -1185,7 +1185,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
             if (ChildTag.Equals(TEXT("default")))
             {
                 // Pass DefNode as RootNode to establish hierarchy
-                ParseDefaultsRecursive(Child, BP, DefNode, XMLDir, ClassName, true);
+                ParseDefaultsRecursive(Child, BP, DefNode, XMLDir, CompilerSettings, ClassName, true);
             }
             // Handle Child Components
             else if (ChildTag.Equals(TEXT("geom")))
@@ -1199,7 +1199,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
                 UMjGeom* GeomComp = Cast<UMjGeom>(GeomNode->ComponentTemplate);
                 if (GeomComp)
                 {
-                    GeomComp->ImportFromXml(Child);
+                    GeomComp->ImportFromXml(Child, CompilerSettings);
                     GeomComp->bIsDefault = true;
                 }
             }
@@ -1214,7 +1214,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
                 UMjJoint* JointComp = Cast<UMjJoint>(JointNode->ComponentTemplate);
                 if (JointComp)
                 {
-                    JointComp->ImportFromXml(Child);
+                    JointComp->ImportFromXml(Child, CompilerSettings);
                     JointComp->bIsDefault = true;
                     UE_LOG(LogURLabEditor, Log, TEXT("  - Found Default Joint: %s (Type Overridden: %s)"), *JointName, JointComp->bOverride_Type ? TEXT("True") : TEXT("False"));
                 }
@@ -1230,7 +1230,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
                 UMjSite* SiteComp = Cast<UMjSite>(SiteNode->ComponentTemplate);
                 if (SiteComp)
                 {
-                    SiteComp->ImportFromXml(Child);
+                    SiteComp->ImportFromXml(Child, CompilerSettings);
                     SiteComp->bIsDefault = true;
                 }
             }
@@ -1245,7 +1245,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
                 UMjCamera* CamComp = Cast<UMjCamera>(CamNode->ComponentTemplate);
                 if (CamComp)
                 {
-                    CamComp->ImportFromXml(Child);
+                    CamComp->ImportFromXml(Child, CompilerSettings);
                     CamComp->bIsDefault = true;
                 }
             }
@@ -1286,7 +1286,7 @@ void UMujocoGenerationAction::ParseDefaultsRecursive(const FXmlNode* Node, UBlue
     {
          for (const FXmlNode* Child : Node->GetChildrenNodes())
          {
-             ParseDefaultsRecursive(Child, BP, RootNode, XMLDir, ParentClassName, bIsDefaultContext);
+             ParseDefaultsRecursive(Child, BP, RootNode, XMLDir, CompilerSettings, ParentClassName, bIsDefaultContext);
          }
     }
 }

--- a/Source/URLabEditor/Private/Tests/MjImportTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjImportTests.cpp
@@ -428,6 +428,61 @@ bool FTest_MjImport_URLab_JointRangeAndDamping::RunTest(const FString&)
     return true;
 }
 
+// Regression: parser used to drop CompilerSettings when recursing into
+// <default> blocks, so joints declared inside a default class always saw
+// the hardcoded bAngleInDegrees=true fallback. For angle="radian" models
+// (e.g. mujoco_menagerie's unitree_go1) the default joint's Range would
+// then be re-scaled by π/180, shrinking ±0.86 rad to ±0.015 rad and
+// making imported robots barely move. Verifies the default joint
+// template keeps its radian value intact.
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjImport_URLab_DefaultClassJointRangeRadians,
+    "URLab.Import.URLab_DefaultClassJointRangeRadians",
+    EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+bool FTest_MjImport_URLab_DefaultClassJointRangeRadians::RunTest(const FString&)
+{
+    FMjXmlImportSession S;
+    if (!S.Init(TEXT(R"(
+        <mujoco>
+          <compiler angle="radian" autolimits="true"/>
+          <default>
+            <default class="hip"><joint range="-0.86 0.86"/></default>
+          </default>
+          <worldbody>
+            <body>
+              <joint class="hip" name="j_hip"/>
+              <geom size=".1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+    )"))) { AddError(S.LastError); return false; }
+
+    UMjJoint* DefaultJoint = nullptr;
+    if (S.Blueprint && S.Blueprint->SimpleConstructionScript)
+    {
+        for (USCS_Node* Node : S.Blueprint->SimpleConstructionScript->GetAllNodes())
+        {
+            UMjJoint* J = Cast<UMjJoint>(Node->ComponentTemplate);
+            if (J && J->bIsDefault) { DefaultJoint = J; break; }
+        }
+    }
+    if (!DefaultJoint) { AddError(TEXT("No default-class joint template found")); S.Cleanup(); return false; }
+
+    if (DefaultJoint->Range.Num() >= 2)
+    {
+        TestNearlyEqual(TEXT("default joint Range[0] preserved as radians"),
+                        DefaultJoint->Range[0], -0.86f, 1e-3f);
+        TestNearlyEqual(TEXT("default joint Range[1] preserved as radians"),
+                        DefaultJoint->Range[1],  0.86f, 1e-3f);
+    }
+    else
+    {
+        AddError(TEXT("default joint Range has < 2 entries"));
+    }
+
+    S.Cleanup();
+    return true;
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FTest_MjImport_URLab_SensorType,
     "URLab.Import.URLab_SensorType",
     EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)

--- a/Source/URLabEditor/Public/MujocoGenerationAction.h
+++ b/Source/URLabEditor/Public/MujocoGenerationAction.h
@@ -159,7 +159,7 @@ public:
     /**
      * @brief Recursively parses XML to find all <default> tags and create UMjDefault components.
      */
-    void ParseDefaultsRecursive(const class FXmlNode* Node, UBlueprint* BP, USCS_Node* RootNode, const FString& XMLDir, const FString& ParentClassName = TEXT(""), bool bIsDefaultContext = true);
+    void ParseDefaultsRecursive(const class FXmlNode* Node, UBlueprint* BP, USCS_Node* RootNode, const FString& XMLDir, const struct FMjCompilerSettings& CompilerSettings, const FString& ParentClassName = TEXT(""), bool bIsDefaultContext = true);
     
     /** @brief Parses XML <contact> section to find <pair> and <exclude> elements and create corresponding components. */
     void ParseContactSection(const class FXmlNode* Node, UBlueprint* BP, USCS_Node* RootNode, const FString& XMLDir);


### PR DESCRIPTION
## Summary

- Thread `FMjCompilerSettings` through `ParseDefaultsRecursive` so `<default>`-block imports see the real `<compiler>` values instead of a default-constructed struct with `bAngleInDegrees=true`.
- Reorder `ParseCompilerSettings` to run *before* `ParseDefaultsRecursive` (it used to run after, which is why the param wasn't available previously).
- Propagate the settings into the four default-block `ImportFromXml` dispatches that accept it (Geom, Joint, Site, Camera). Actuator `ctrlrange` handling is raw pass-through and already correct.
- New Tier-2 regression test `URLab.Import.URLab_DefaultClassJointRangeRadians` imports an `angle="radian"` model with a default-class joint range and asserts the template's `Range` stays at the XML value (±0.86 rad), catching the previous degree-to-radian mis-conversion.

## Motivation

Symptom reported after importing `mujoco_menagerie/unitree_go1/go1.xml`: "it plays but when I control the joints they barely move, like they're operating in degrees." The MJCF uses the standard menagerie idiom:

```xml
<compiler angle="radian" autolimits="true"/>
<default>
  <default class="abduction"><joint range="-0.863 0.863"/></default>
  ...
</default>
<worldbody>
  <body><joint class="abduction" .../>...</body>
</worldbody>
```

Every joint is a default-class reference. The importer parsed each `<default>` block via `ParseDefaultsRecursive` and then called `ComponentType::ImportFromXml(Child)` **without passing `CompilerSettings`**, so `UMjJoint::ImportFromXml` saw a default-constructed `FMjCompilerSettings{}` with `bAngleInDegrees=true` regardless of the real `<compiler>` setting. The subsequent deg→rad conversion in `MjJoint.cpp:115-120` then incorrectly rescaled the already-radian range values by π/180, collapsing ±0.863 rad to ±0.015 rad (≈±0.86°). Joints compiled with ultra-tight limits and controllers couldn't move them. Non-default joints (which flow through the other `ImportFromXml` call site that passes `CompilerSettings`) always worked — so the bug only affected the common-case default-inheritance idiom.

Latent since the initial release; never fired in the test suite because none of the Tier-2 default tests exercised `angle="radian"` ranges.

## Linked issue

None — user-reported during go1 import.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-19 18:02:29 UTC
Host      : buzz-main
Git HEAD  : fa1069c2 (fix/default-class-compiler-settings)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : /tmp/urlab_test.log  (sha256: 89f5fcd59a6b4966)
================================
```

One test added (`URLab.Import.URLab_DefaultClassJointRangeRadians`), so count rises from 174 → 175.

## Manual verification steps

1. Import `mujoco_menagerie/unitree_go1/go1.xml` via the URLab importer. Open the generated Blueprint, drop it into a level, hit Play.
2. Send control signals to any of the 12 joint actuators (`FR_hip`, `FR_thigh`, `FR_calf`, …). Joints should traverse their full declared range — e.g. `FR_thigh` should swing through `[-0.686, 4.501]` rad, roughly -39° to +258° — not barely-perceptibly as before.
3. As a spot check, open the imported BP's default-class components (`Default_abduction`, `Default_hip`, `Default_knee`) and verify each `Joint.Range` matches the XML: e.g. `abduction` → `[-0.863, 0.863]`, not `[-0.015, 0.015]`.
4. Re-run the automation suite; expect `URLab.Import.URLab_DefaultClassJointRangeRadians` to pass, total `175 / 175`.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes (175 / 175)
- [x] Docs updated for user-facing changes (n/a — bug fix, no API surface change)