### PR TITLE
Make perturb select work on imported mesh visuals (overlap trace)

### DIFF
--- a/Source/URLab/Private/MuJoCo/Input/MjPerturbation.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjPerturbation.cpp
@@ -157,17 +157,29 @@ void UMjPerturbation::HandleSelect(const FVector& CursorOrigin, const FVector& C
     }
 
     // Line trace from cursor. Distance is generous — 1 km covers typical
-    // scene scales.
+    // scene scales. Use Multi rather than Single because imported visual
+    // meshes are configured with ECR_Overlap responses (see the importer):
+    // SingleByChannel only returns blocking hits, so it would pass straight
+    // through go1-style mesh-geom-only articulations. Multi collects both
+    // block and overlap hits; we pick the first that resolves to an MjBody.
     const FVector TraceEnd = CursorOrigin + CursorDirection.GetSafeNormal() * 100000.0f;
-    FHitResult Hit;
+    TArray<FHitResult> Hits;
     FCollisionQueryParams Params;
     Params.bTraceComplex = false;
-    GetWorld()->LineTraceSingleByChannel(Hit, CursorOrigin, TraceEnd, ECC_Visibility, Params);
+    GetWorld()->LineTraceMultiByChannel(Hits, CursorOrigin, TraceEnd, ECC_Visibility, Params);
 
     int32 BodyId = -1;
-    if (Hit.bBlockingHit && Hit.GetActor())
+    FHitResult SelectedHit;
+    for (const FHitResult& H : Hits)
     {
-        BodyId = ResolveBodyIdFromActor(Hit.GetActor(), Hit.ImpactPoint);
+        if (!H.GetActor()) continue;
+        const int32 Resolved = ResolveBodyIdFromActor(H.GetActor(), H.ImpactPoint);
+        if (Resolved > 0)
+        {
+            BodyId = Resolved;
+            SelectedHit = H;
+            break;
+        }
     }
 
     FScopeLock Lock(&Manager->PhysicsEngine->CallbackMutex);
@@ -178,7 +190,7 @@ void UMjPerturbation::HandleSelect(const FVector& CursorOrigin, const FVector& C
     {
         // Compute localpos = xmat[sel]^T * (world_hit - xpos[sel])
         mjtNum HitMj[3];
-        MjUtils::UEToMjPosition(Hit.ImpactPoint, HitMj);
+        MjUtils::UEToMjPosition(SelectedHit.ImpactPoint, HitMj);
 
         mjtNum Diff[3];
         mju_sub3(Diff, HitMj, d->xpos + 3 * BodyId);
@@ -189,10 +201,10 @@ void UMjPerturbation::HandleSelect(const FVector& CursorOrigin, const FVector& C
         Perturb.skinselect  = -1;
         Perturb.active      = 0;
 
-        ClickHitWorldUE = Hit.ImpactPoint;
+        ClickHitWorldUE = SelectedHit.ImpactPoint;
 
         UE_LOG(LogURLab, Log, TEXT("[MjPerturbation] Selected body %d (%s) at world %s"),
-            BodyId, *Hit.GetActor()->GetName(), *Hit.ImpactPoint.ToString());
+            BodyId, *SelectedHit.GetActor()->GetName(), *SelectedHit.ImpactPoint.ToString());
     }
     else
     {


### PR DESCRIPTION
## Summary

- Switch `UMjPerturbation::HandleSelect` from `LineTraceSingleByChannel` to `LineTraceMultiByChannel` and pick the first hit that resolves to an `MjBody`.
- Leaves the importer's collision setup untouched (imported visual meshes stay `QueryOnly` + `Overlap`, which is intentional so they don't block player movement).

## Motivation

Reported: "I can't perturbation-select the go1 articulation. It works fine when the articulation has primitives but double-click doesn't do anything on regular static meshes."

The cause is a collision-response mismatch between primitive and mesh geoms:

- Primitive visualizers set `QueryOnly` collision but leave channel responses at the engine default — `Block` on `ECC_Visibility`. `LineTraceSingleByChannel` returns a blocking hit. Perturbation's select-by-actor logic then walks up to the articulation and resolves a `body_id`. Works.
- Imported mesh visualizers are set by [MujocoXmlParser.cpp:469-470](Source/URLabEditor/Private/MujocoXmlParser.cpp#L469-L470) to `QueryOnly` + `SetCollisionResponseToAllChannels(ECR_Overlap)`. `LineTraceSingleByChannel` ignores overlap responses — the ray passes straight through the mesh and returns no hit. For articulations whose only visible components are mesh geoms (most of `mujoco_menagerie`, including go1), double-click never lands on anything.

Using `LineTraceMultiByChannel` collects both block and overlap hits. We iterate front-to-back and pick the first one that resolves to a valid `MjBody`, so:

- Primitive-only articulations: first hit is still the blocking primitive → same behaviour as before.
- Mesh-only articulations: first hit is the overlap against the visual mesh → resolves the body correctly.
- Mixed: whichever component the ray actually meets first wins.

Keeping the importer's `Overlap` response unchanged avoids regressing anything that currently relies on imported visuals being passthrough (player movement, other traces).

## Linked issue

None — user-reported during go1 perturbation testing.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-19 18:18:22 UTC
Host      : buzz-main
Git HEAD  : a4a5665b (fix/perturb-select-mesh-overlap)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : /tmp/urlab_test.log  (sha256: 3ed6cc26520af6c9)
================================
```

No new tests: `HandleSelect` depends on a live UE world + spawned physics + line traces against real mesh collision, which the existing `FMjXmlImportSession` Tier-2 import tests don't model. Verified manually against go1.

## Manual verification steps

1. Import any menagerie model that uses mesh visuals (e.g. `unitree_go1/go1.xml`) — or any articulation with only `type="mesh"` geoms.
2. In PIE, press `Shift+F1` to get a visible cursor, then **double-click LMB** on one of the visual mesh parts (a leg, trunk, etc.). Expect a red selection marker to appear at the hit point — and the log to emit `[MjPerturbation] Selected body <id> (<actor>) at world ...`.
3. **Ctrl + RMB drag** to translate, or **Ctrl + LMB drag** to rotate. Body should respond to the drag.
4. Re-run on a primitive-only articulation (e.g. the existing box/sphere demo scenes) and confirm nothing regressed — the same double-click still works.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes (175 / 175)
- [x] Docs updated for user-facing changes (n/a — no API surface change)