### PR TITLE
Fix intermittent URLab automation-suite abort (Kismet2.cpp:424 assertion)

### DIFF
--- a/Source/URLabEditor/Private/Tests/MjTestHelpers.h
+++ b/Source/URLabEditor/Private/Tests/MjTestHelpers.h
@@ -366,13 +366,19 @@ struct FMjXmlImportSession
             mj_deleteModel(TmpM);
         }
 
-        // Create Blueprint and run generator
+        // Create Blueprint and run generator. Both the package path AND the
+        // blueprint class name are unique-per-session — hardcoding the class
+        // name caused intermittent Kismet2.cpp:424 FindObject-uniqueness
+        // assertion failures when GC hadn't collected the previous test's
+        // blueprint-generated class before the next test ran.
+        const FString UniqueSfx = FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(12);
         FString PkgName = UPackageTools::SanitizePackageName(
-            TEXT("/Temp/URLabImportTest_") + FString::FromInt(FMath::RandRange(0, 999999)));
+            FString(TEXT("/Temp/URLabImportTest_")) + UniqueSfx);
         UPackage* Pkg = CreatePackage(*PkgName);
 
+        const FString BPName = FString(TEXT("ImportTestArt_")) + UniqueSfx;
         Blueprint = FKismetEditorUtilities::CreateBlueprint(
-            AMjArticulation::StaticClass(), Pkg, TEXT("ImportTestArt"),
+            AMjArticulation::StaticClass(), Pkg, *BPName,
             BPTYPE_Normal, UBlueprint::StaticClass(), UBlueprintGeneratedClass::StaticClass());
 
         if (!Blueprint)
@@ -426,13 +432,18 @@ struct FMjXmlImportSession
             mj_deleteModel(TmpM);
         }
 
-        // 3. Create in-memory Blueprint
+        // 3. Create in-memory Blueprint. Both the package path AND the
+        //    blueprint class name are unique-per-session (GUID suffix). See
+        //    InitFromFile above for the rationale — hardcoded class names
+        //    caused intermittent Kismet2.cpp:424 uniqueness assertions.
+        const FString UniqueSfx = FGuid::NewGuid().ToString(EGuidFormats::Digits).Left(12);
         FString PkgName = UPackageTools::SanitizePackageName(
-            TEXT("/Temp/URLabImportTest_") + FString::FromInt(FMath::RandRange(0, 999999)));
+            FString(TEXT("/Temp/URLabImportTest_")) + UniqueSfx);
         UPackage* Pkg = CreatePackage(*PkgName);
 
+        const FString BPName = FString(TEXT("ImportTestArt_")) + UniqueSfx;
         Blueprint = FKismetEditorUtilities::CreateBlueprint(
-            AMjArticulation::StaticClass(), Pkg, TEXT("ImportTestArt"),
+            AMjArticulation::StaticClass(), Pkg, *BPName,
             BPTYPE_Normal, UBlueprint::StaticClass(), UBlueprintGeneratedClass::StaticClass());
 
         if (!Blueprint)


### PR DESCRIPTION
## Summary

- Give every `FMjXmlImportSession` a fresh 12-char GUID suffix and apply it to **both** the scratch package path and the blueprint class name it generates. Previously only the package path was randomised; the class name was always `ImportTestArt`, which let back-to-back runs collide in UE's blueprint-generated-class name checks and abort the whole automation run mid-suite.

## Motivation

The URLab suite was aborting intermittently at `URLab.Import.RoundTrip_Frame_KnownGap` (or sometimes nearby tests) with

```
Assertion failed: FindObject<UBlueprint>(Outer, *NewBPName.ToString()) == 0
[File: …/Kismet2/Kismet2.cpp] [Line: 424]
```

That's UE's sanity check in the blueprint-duplication path: *no blueprint with this name should already exist at the given outer.* Each `FMjXmlImportSession::Init` / `InitFromFile` was calling:

```cpp
UPackage* Pkg = CreatePackage(TEXT("/Temp/URLabImportTest_") + RandInt);
Blueprint = FKismetEditorUtilities::CreateBlueprint(
    …, Pkg, TEXT("ImportTestArt"), …);
```

Unique package, **hardcoded class name**. When the generator then compiled the blueprint, the secondary objects it produces (`UBlueprintGeneratedClass` and related) landed with predictable, reused names at outers that Kismet checks via `FindObject` — and if the previous test's blueprint hadn't been GC'd yet, the assertion tripped. The check is name-based; the random package path didn't protect it.

Symptom in numbers: 20-run pre-fix baseline showed ~1-in-5 runs aborting early at 56 or 82 tests instead of completing the full 175. That was the flake we kept hitting during rebase workflows and that forced PR re-runs.

Fix is a two-line change: derive one 12-char GUID suffix per session and use it for both the package path and the blueprint class name. Uniqueness sidesteps the `FindObject` check no matter what outer Kismet picks internally.

## Linked issue

Related to the flake flagged in PR #18 and again during the #28 verification — not tracked as a standalone issue until now.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-19 18:38:34 UTC
Host      : buzz-main
Git HEAD  : 577e78f1 (fix/test-blueprint-name-flake)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : /tmp/urlab_test.log  (sha256: a161db6fda75c15e)
================================
```

Plus a soak test: 20 consecutive invocations of `Scripts/build_and_test.sh` post-fix, all 175 / 175 clean, zero aborts. Under the pre-fix ~1-in-5 failure rate, 20 consecutive clean runs would be about a 1% event, so this is a high-confidence result.

## Manual verification steps

1. `./Scripts/build_and_test.sh --engine … --project …` in a loop (10+ iterations). Every run should report `Tests: 175 / 175 passed (0 failed)` with no early termination.
2. Grep the individual log files for `Failed to register test with the name 'FTest_`; there should be **none** (the old symptom produced these warnings before the hard assertion).
3. Session Frontend: run `URLab.Import.RoundTrip_Frame_KnownGap` in isolation and back-to-back several times; should pass every time.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes (175 / 175) — 20 consecutive clean runs
- [x] Docs updated for user-facing changes (n/a — test-infrastructure only)