### PR TITLE
Truncate test log up-front in build+test scripts

### DIFF
--- a/Scripts/build_and_test.ps1
+++ b/Scripts/build_and_test.ps1
@@ -51,6 +51,11 @@ $cmd = Join-Path $Engine 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
 if (-not (Test-Path $ubt)) { Write-Error "UBT not found: $ubt";                exit 3 }
 if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   exit 3 }
 
+# Truncate the test log up-front so a build failure (or any early exit
+# before UnrealEditor-Cmd writes to it) doesn't leave the SHA-256 in the
+# summary pointing at a previous run's file.
+Set-Content -Path $Log -Value '' -NoNewline
+
 # --- Build -----------------------------------------------------------------
 Write-Host ">>> Building $Target (Win64 Development)..."
 $buildArgs = @($Target, 'Win64', 'Development', "-Project=$Project", '-WaitMutex')

--- a/Scripts/build_and_test.sh
+++ b/Scripts/build_and_test.sh
@@ -80,6 +80,11 @@ CMD="$ENGINE/Engine/Binaries/Win64/UnrealEditor-Cmd.exe"
 [[ -x "$UBT" ]] || { echo "UBT not found: $UBT" >&2; exit 3; }
 [[ -x "$CMD" ]] || { echo "UnrealEditor-Cmd not found: $CMD" >&2; exit 3; }
 
+# Truncate the test log up-front so a build failure (or any early exit
+# before UnrealEditor-Cmd writes to it) doesn't leave the SHA-256 in the
+# summary pointing at a previous run's file.
+: > "$LOG"
+
 # --- Build -----------------------------------------------------------------
 echo ">>> Building $TARGET (Win64 Development)..."
 BUILD_OUT=$("$UBT" "$TARGET" Win64 Development "-Project=$PROJECT" -WaitMutex 2>&1 || true)


### PR DESCRIPTION
## Summary

- `Scripts/build_and_test.sh` and `Scripts/build_and_test.ps1` now clear the test-log file at the start of each run, before the build step.
- When a build fails and the test phase is skipped, the summary block's `Log: … (sha256: …)` line now shows `n/a` via the existing empty-file fallback, instead of fingerprinting a previous run's file.

## Motivation

Noticed while chasing the Kismet flake: a Live-Coding-blocked build produced

```
Build     : Failed
Tests     : 0 / 0 passed (0 failed)
Log       : /tmp/urlab_test.log  (sha256: 3ed6cc26520af6c9)  ← prior run
```

The log file wasn't touched, so its SHA still referred to the previous successful run. Pasted into a PR that would be misleading — the evidence block implies a real log was produced for this build. Truncating up-front keeps the block honest.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-19 18:43:24 UTC
Host      : buzz-main
Git HEAD  : 0bdabf77 (fix/build-test-script-stale-log)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : /tmp/urlab_test.log  (sha256: 746fcf829063070b)
================================
```

## Manual verification steps

1. Run `./Scripts/build_and_test.sh --engine … --project …` once against a healthy checkout. Summary shows real test counts + non-zero SHA.
2. Open the UE editor (to hold the Live Coding mutex) and run the script again — it'll report `Build: Failed`. The `Log:` line should now say `(sha256: n/a)` rather than a hex string from an earlier run.
3. Equivalent check via PowerShell: `.\Scripts\build_and_test.ps1 -Engine … -Project …`.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes (175 / 175)
- [x] Docs updated for user-facing changes (n/a — scripts only)