### PR TITLE
Stabilize physics thread: MuJoCo error hook + race fixes + camera cleanup

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Deformable/MjFlexcomp.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Deformable/MjFlexcomp.cpp
@@ -38,6 +38,7 @@
 #include "MuJoCo/Core/MjPhysicsEngine.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+#include "Misc/ScopeTryLock.h"
 #include "HAL/FileManager.h"
 #include "Interfaces/IPluginManager.h"
 
@@ -205,11 +206,22 @@ void UMjFlexcomp::ImportFromXml(const FXmlNode* Node)
 
             FString IntStr = Child->GetAttribute(TEXT("internal"));
             if (!IntStr.IsEmpty()) { bInternal = IntStr.ToBool(); bOverride_Internal = true; }
+
+            MjXmlUtils::ReadAttrFloatArray(Child, TEXT("friction"), Friction, bOverride_Friction);
+            MjXmlUtils::ReadAttrFloat     (Child, TEXT("solmix"),   SolMix,   bOverride_SolMix);
+            MjXmlUtils::ReadAttrFloatArray(Child, TEXT("solref"),   ContactSolRef, bOverride_ContactSolRef);
+            MjXmlUtils::ReadAttrFloatArray(Child, TEXT("solimp"),   ContactSolImp, bOverride_ContactSolImp);
         }
         else if (ChildTag == TEXT("edge"))
         {
             MjXmlUtils::ReadAttrFloat(Child, TEXT("stiffness"), EdgeStiffness, bOverride_EdgeStiffness);
-            MjXmlUtils::ReadAttrFloat(Child, TEXT("damping"), EdgeDamping, bOverride_EdgeDamping);
+            MjXmlUtils::ReadAttrFloat(Child, TEXT("damping"),   EdgeDamping,   bOverride_EdgeDamping);
+
+            FString EqStr = Child->GetAttribute(TEXT("equality"));
+            if (!EqStr.IsEmpty()) { bEdgeEquality = EqStr.ToBool(); bOverride_EdgeEquality = true; }
+
+            MjXmlUtils::ReadAttrFloatArray(Child, TEXT("solref"), EdgeSolRef, bOverride_EdgeSolRef);
+            MjXmlUtils::ReadAttrFloatArray(Child, TEXT("solimp"), EdgeSolImp, bOverride_EdgeSolImp);
         }
         else if (ChildTag == TEXT("elasticity"))
         {
@@ -459,6 +471,18 @@ FString UMjFlexcomp::BuildFlexcompXml(const FString& MeshAssetName) const
     // and only emit the overridden attributes inside.
     FString SubElements;
 
+    // Small helper: join a float array into a space-separated string.
+    auto JoinFloats = [](const TArray<float>& Arr) -> FString
+    {
+        FString Out;
+        for (int32 i = 0; i < Arr.Num(); ++i)
+        {
+            if (i > 0) Out += TEXT(" ");
+            Out += FString::Printf(TEXT("%f"), Arr[i]);
+        }
+        return Out;
+    };
+
     // <contact>
     {
         FString ContactAttrs;
@@ -480,6 +504,14 @@ FString UMjFlexcomp::BuildFlexcompXml(const FString& MeshAssetName) const
         {
             ContactAttrs += FString::Printf(TEXT(" internal=\"%s\""), bInternal ? TEXT("true") : TEXT("false"));
         }
+        if (bOverride_Friction && Friction.Num() > 0)
+            ContactAttrs += FString::Printf(TEXT(" friction=\"%s\""), *JoinFloats(Friction));
+        if (bOverride_SolMix)
+            ContactAttrs += FString::Printf(TEXT(" solmix=\"%f\""), SolMix);
+        if (bOverride_ContactSolRef && ContactSolRef.Num() > 0)
+            ContactAttrs += FString::Printf(TEXT(" solref=\"%s\""), *JoinFloats(ContactSolRef));
+        if (bOverride_ContactSolImp && ContactSolImp.Num() > 0)
+            ContactAttrs += FString::Printf(TEXT(" solimp=\"%s\""), *JoinFloats(ContactSolImp));
         if (!ContactAttrs.IsEmpty())
         {
             SubElements += FString::Printf(TEXT("<contact%s/>"), *ContactAttrs);
@@ -491,6 +523,12 @@ FString UMjFlexcomp::BuildFlexcompXml(const FString& MeshAssetName) const
         FString EdgeAttrs;
         if (bOverride_EdgeStiffness) EdgeAttrs += FString::Printf(TEXT(" stiffness=\"%f\""), EdgeStiffness);
         if (bOverride_EdgeDamping)   EdgeAttrs += FString::Printf(TEXT(" damping=\"%f\""), EdgeDamping);
+        if (bOverride_EdgeEquality)
+            EdgeAttrs += FString::Printf(TEXT(" equality=\"%s\""), bEdgeEquality ? TEXT("true") : TEXT("false"));
+        if (bOverride_EdgeSolRef && EdgeSolRef.Num() > 0)
+            EdgeAttrs += FString::Printf(TEXT(" solref=\"%s\""), *JoinFloats(EdgeSolRef));
+        if (bOverride_EdgeSolImp && EdgeSolImp.Num() > 0)
+            EdgeAttrs += FString::Printf(TEXT(" solimp=\"%s\""), *JoinFloats(EdgeSolImp));
         if (!EdgeAttrs.IsEmpty())
         {
             SubElements += FString::Printf(TEXT("<edge%s/>"), *EdgeAttrs);
@@ -575,6 +613,12 @@ void UMjFlexcomp::RegisterToSpec(FMujocoSpecWrapper& Wrapper, mjsBody* ParentBod
     FString FlexcompXml = BuildFlexcompXml(MeshAssetName);
     FString FullXml = FString::Printf(
         TEXT("<mujoco><worldbody>%s</worldbody></mujoco>"), *FlexcompXml);
+
+    // Dump the exact fragment we hand to MuJoCo so we can verify
+    // override emission + see what the compile is actually seeing.
+    UE_LOG(LogURLab, Log,
+        TEXT("[MjFlexcomp] '%s' MJCF fragment:\n%s"),
+        *FlexName, *FlexcompXml);
 
     // 3. Parse into temp spec — MuJoCo expands the flexcomp macro
     char ErrBuf[1000] = "";
@@ -733,19 +777,23 @@ void UMjFlexcomp::UpdateProceduralMesh()
         ? DynamicMesh->GetAttachParent()->GetComponentTransform()
         : FTransform::Identity;
 
-    // Read welded flex positions (lock mutex to avoid torn reads from physics thread)
+    // Read welded flex positions under the physics mutex to avoid torn reads.
     TArray<FVector> WeldedPositions;
     WeldedPositions.SetNum(FlexVertNum);
 
     AAMjManager* Manager = AAMjManager::GetManager();
     UMjPhysicsEngine* Engine = Manager ? Manager->PhysicsEngine : nullptr;
+
     {
-        TOptional<FScopeLock> Lock;
-        if (Engine) Lock.Emplace(&Engine->CallbackMutex);
+        FScopeTryLock ScopeLock(Engine ? &Engine->CallbackMutex : nullptr);
+        if (Engine && !ScopeLock.IsLocked())
+        {
+            return;
+        }
         for (int32 i = 0; i < FlexVertNum; i++)
         {
-            int32 Idx = (FlexVertAdr + i) * 3;
-            FVector WorldPos = MjUtils::MjToUEPosition(&m_Data->flexvert_xpos[Idx]);
+            const int32 Idx = (FlexVertAdr + i) * 3;
+            const FVector WorldPos = MjUtils::MjToUEPosition(&m_Data->flexvert_xpos[Idx]);
             WeldedPositions[i] = ParentTransform.InverseTransformPosition(WorldPos);
         }
     }
@@ -754,8 +802,8 @@ void UMjFlexcomp::UpdateProceduralMesh()
     {
         for (int32 i = 0; i < NumRenderVerts; i++)
         {
-            int32 W = RawToWelded[i];
-            FVector P = (W >= 0 && W < FlexVertNum) ? WeldedPositions[W] : FVector::ZeroVector;
+            const int32 W = RawToWelded[i];
+            const FVector P = (W >= 0 && W < FlexVertNum) ? WeldedPositions[W] : FVector::ZeroVector;
             Mesh.SetVertex(i, FVector3d(P.X, P.Y, P.Z));
         }
     }, EDynamicMeshComponentRenderUpdateMode::NoUpdate);

--- a/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
@@ -296,7 +296,6 @@ void UMjQuickConvertComponent::UpdateUETransform() {
 
         m_actor->SetActorRotation(_quat);
         m_actor->SetActorLocation(_pos);
-
 }
 
 void UMjQuickConvertComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) {
@@ -306,7 +305,7 @@ void UMjQuickConvertComponent::TickComponent(float DeltaTime, ELevelTick TickTyp
     {
         UpdateUETransform();
     }
-    
+
     if (m_debug_meshes)
     {
         DrawDebugCollision();

--- a/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
@@ -314,10 +314,11 @@ void UMjCamera::TickComponent(float DeltaTime, ELevelTick TickType,
             RefreshHiddenComponentsFromSegPools();
         }
 
-        // Explicit capture each tick — bCaptureEveryFrame should handle this
-        // but calling it explicitly ensures the first frame fires even if
-        // the component was registered after the initial world tick.
-        CaptureComponent->CaptureScene();
+        // bCaptureEveryFrame (set by SetStreamingEnabled) drives the per-tick
+        // capture. Calling CaptureScene() again here is redundant — UE warns
+        // "Scene capture with bCaptureEveryFrame enabled was told to update —
+        // major inefficiency", and under sustained render pressure the doubled
+        // command submission can leave RHI frame breadcrumbs unbalanced.
     }
 
     // Check if an in-flight readback has completed

--- a/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
@@ -214,13 +214,31 @@ void AAMjManager::EndPlay(const EEndPlayReason::Type EndPlayReason) {
     Super::EndPlay(EndPlayReason);
     if (Instance == this) Instance = nullptr;
 
-    // Signal the async thread to stop and wait for it to exit
+    // Signal the async thread to stop and wait for it to exit — but bound the
+    // wait. If mj_step is mid-call on a pathological flex state, the step can
+    // take many seconds (or effectively hang). An unbounded Wait() here would
+    // freeze the editor's PIE-stop; the user sees UE never coming back. With
+    // the timeout we instead detach: the async thread keeps running in the
+    // background until its current mj_step returns, then finds bShouldStopTask
+    // set and exits cleanly on its own. Cost is a one-time memory leak (we
+    // can't delete m_model / m_data while the thread may still read them).
+    bool bAsyncExited = true;
     if (PhysicsEngine)
     {
         PhysicsEngine->bShouldStopTask = true;
         if (PhysicsEngine->AsyncPhysicsFuture.IsValid())
         {
-            PhysicsEngine->AsyncPhysicsFuture.Wait();
+            constexpr double kShutdownTimeoutSec = 3.0;
+            bAsyncExited = PhysicsEngine->AsyncPhysicsFuture.WaitFor(
+                FTimespan::FromSeconds(kShutdownTimeoutSec));
+            if (!bAsyncExited)
+            {
+                UE_LOG(LogURLab, Warning,
+                    TEXT("Physics async thread did not exit within %.1fs — detaching. ")
+                    TEXT("mj_step is likely stuck; MuJoCo resources will leak for this session ")
+                    TEXT("to avoid a use-after-free in the still-running step."),
+                    kShutdownTimeoutSec);
+            }
         }
         PhysicsEngine->ClearCallbacks();
     }
@@ -239,8 +257,9 @@ void AAMjManager::EndPlay(const EEndPlayReason::Type EndPlayReason) {
         }
     }
 
-    // Safe to delete MuJoCo resources — async thread has exited
-    if (PhysicsEngine)
+    // Only touch MuJoCo resources if the async thread actually exited — a
+    // detached thread may still be executing mj_step and reading these.
+    if (PhysicsEngine && bAsyncExited)
     {
         if (PhysicsEngine->m_data)
         {

--- a/Source/URLab/Private/MuJoCo/Core/MjArticulation.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjArticulation.cpp
@@ -611,11 +611,14 @@ void AMjArticulation::PostSetup(mjModel* Model, mjData* Data)
            *GetName(), *m_prefix, ActuatorIdMap.Num(), JointIdMap.Num(), SensorIdMap.Num(), BodyIdMap.Num(), TendonIdMap.Num());
 
     // Bind any articulation controller component (PD, passthrough, or user-custom)
-    if (UMjArticulationController* Ctrl = FindComponentByClass<UMjArticulationController>())
+    // and cache it so ApplyControls (physics thread) doesn't have to iterate
+    // OwnedComponents on every step — that race causes crashes under flex load.
+    CachedController = FindComponentByClass<UMjArticulationController>();
+    if (CachedController)
     {
-        Ctrl->Bind(m_model, m_data, ActuatorIdMap);
+        CachedController->Bind(m_model, m_data, ActuatorIdMap);
         UE_LOG(LogURLab, Log, TEXT("AMjArticulation::PostSetup - Bound controller '%s' with %d actuators"),
-               *Ctrl->GetClass()->GetName(), Ctrl->GetNumBindings());
+               *CachedController->GetClass()->GetName(), CachedController->GetNumBindings());
     }
 }
 
@@ -665,11 +668,12 @@ void AMjArticulation::ApplyControls()
         return;
     }
 
-    // Delegate to custom controller if present and active
-    UMjArticulationController* Ctrl = FindComponentByClass<UMjArticulationController>();
-    if (Ctrl && Ctrl->bEnabled && Ctrl->IsBound())
+    // Delegate to custom controller if present and active. Use the cached
+    // pointer from PostSetup — iterating OwnedComponents on the physics
+    // thread races against game-thread mutations and corrupts nearby heap.
+    if (CachedController && CachedController->bEnabled && CachedController->IsBound())
     {
-        Ctrl->ComputeAndApply(m_model, m_data, ControlSource);
+        CachedController->ComputeAndApply(m_model, m_data, ControlSource);
         return;
     }
 

--- a/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
@@ -28,13 +28,107 @@
 #include "MuJoCo/Core/AMjManager.h"
 #include "Kismet/GameplayStatics.h"
 #include "HAL/FileManager.h"
+#include "Async/Future.h"
 #include "Misc/Paths.h"
 #include "XmlFile.h"
 #include "Internationalization/Regex.h"
 #include "Utils/URLabLogging.h"
+#include <atomic>
 #if WITH_EDITOR
 #include "Misc/MessageDialog.h"
 #endif
+
+// Installed as mju_user_error / mju_user_warning so MuJoCo's fatal-error
+// path logs via UE_LOG instead of calling exit(1). Without this, any MuJoCo
+// internal invariant violation (e.g. "mj_sleep: found sleeping tree N in
+// island M" on flex × free-body + SLEEP + MULTICCD) terminates the process:
+// exit() unwinds every live FRHIBreadcrumbEventManual's TOptional across
+// threads and trips the !Node assertion, killing the editor. Messages are
+// deduplicated + throttled so pathological per-step errors can't flood the
+// log at step rate.
+static FCriticalSection GMujocoLogMutex;
+static TMap<FString, int64> GMujocoMsgHistory;  // message text -> next step count at which to log
+static std::atomic<int64>   GMujocoMsgStepCounter{0};
+
+static void URLab_LogMujocoMessage(const TCHAR* Severity, const char* Msg, ELogVerbosity::Type Verbosity)
+{
+    const FString Text = Msg ? FString(UTF8_TO_TCHAR(Msg)) : FString(TEXT("(null)"));
+    const int64 Step = GMujocoMsgStepCounter.fetch_add(1, std::memory_order_relaxed);
+
+    int64 FirstHitStep = -1;
+    int64 HitCountSinceLastLog = 0;
+    {
+        FScopeLock Lock(&GMujocoLogMutex);
+        int64* NextLog = GMujocoMsgHistory.Find(Text);
+        if (!NextLog)
+        {
+            // First occurrence — log it and start counting future hits.
+            GMujocoMsgHistory.Add(Text, Step + 500);  // log again after 500 more messages
+            FirstHitStep = Step;
+        }
+        else if (Step >= *NextLog)
+        {
+            HitCountSinceLastLog = 500;  // approx — we don't track exact
+            *NextLog = Step + 500;
+            FirstHitStep = Step;
+        }
+    }
+
+    if (FirstHitStep >= 0)
+    {
+        if (HitCountSinceLastLog > 0)
+        {
+            UE_LOG(LogURLab, Warning, TEXT("[MuJoCo %s x~%lld] %s"), Severity, (long long)HitCountSinceLastLog, *Text);
+        }
+        else
+        {
+            if (Verbosity == ELogVerbosity::Error)
+            {
+                UE_LOG(LogURLab, Error, TEXT("[MuJoCo %s] %s"), Severity, *Text);
+            }
+            else
+            {
+                UE_LOG(LogURLab, Warning, TEXT("[MuJoCo %s] %s"), Severity, *Text);
+            }
+        }
+    }
+}
+
+static void URLab_OnMujocoError(const char* Msg)
+{
+    URLab_LogMujocoMessage(TEXT("fatal"), Msg, ELogVerbosity::Error);
+}
+
+static void URLab_OnMujocoWarning(const char* Msg)
+{
+    URLab_LogMujocoMessage(TEXT("warn"), Msg, ELogVerbosity::Warning);
+}
+
+static bool GMujocoCallbacksInstalled = false;
+static void URLab_InstallMujocoCallbacks()
+{
+    if (GMujocoCallbacksInstalled) return;
+
+    // mujoco.dll is delay-loaded in URLab's Build.cs, and the linker refuses
+    // to bind data symbols through a delayed import. Resolve the two
+    // mju_user_* function pointers manually via GetDllExport.
+    void* Handle = FPlatformProcess::GetDllHandle(TEXT("mujoco.dll"));
+    if (!Handle)
+    {
+        UE_LOG(LogURLab, Warning, TEXT("[URLab] Could not resolve mujoco.dll to install error callbacks"));
+        return;
+    }
+
+    using ErrorFnPtr = void(*)(const char*);
+    // GetDllExport(hMod, "mju_user_error") returns the address of the
+    // exported variable itself — i.e. an ErrorFnPtr*.
+    ErrorFnPtr* PErr  = reinterpret_cast<ErrorFnPtr*>(FPlatformProcess::GetDllExport(Handle, TEXT("mju_user_error")));
+    ErrorFnPtr* PWarn = reinterpret_cast<ErrorFnPtr*>(FPlatformProcess::GetDllExport(Handle, TEXT("mju_user_warning")));
+    if (PErr)  { *PErr  = &URLab_OnMujocoError;   }
+    if (PWarn) { *PWarn = &URLab_OnMujocoWarning; }
+    UE_LOG(LogURLab, Log, TEXT("[URLab] MuJoCo error callbacks installed (err=%p warn=%p)"), (void*)PErr, (void*)PWarn);
+    GMujocoCallbacksInstalled = true;
+}
 
 UMjPhysicsEngine::UMjPhysicsEngine()
 {
@@ -43,6 +137,8 @@ UMjPhysicsEngine::UMjPhysicsEngine()
     Options.bOverride_Integrator = true;
     Options.Integrator = EMjIntegrator::ImplicitFast;
     ControlSource = EControlSource::ZMQ;
+
+    URLab_InstallMujocoCallbacks();
 }
 
 void UMjPhysicsEngine::PreCompile()
@@ -237,7 +333,7 @@ void UMjPhysicsEngine::RunMujocoAsync()
 
         while (true)
         {
-            double LoopStartTime = FPlatformTime::Seconds();
+            const double LoopStartTime = FPlatformTime::Seconds();
 
             if (bShouldStopTask)
                 break;
@@ -283,7 +379,6 @@ void UMjPhysicsEngine::RunMujocoAsync()
                     }
                 }
 
-                // Pre-step callbacks (replaces direct ZmqComponent->PreStep calls)
                 for (const FPhysicsCallback& Cb : PreStepCallbacks)
                 {
                     Cb(m_model, m_data);
@@ -302,13 +397,11 @@ void UMjPhysicsEngine::RunMujocoAsync()
                         mj_step(m_model, m_data);
                 }
 
-                // Post-step callbacks (replaces direct ZmqComponent->PostStep calls)
                 for (const FPhysicsCallback& Cb : PostStepCallbacks)
                 {
                     Cb(m_model, m_data);
                 }
 
-                // Replay/Recording post-step callback
                 if (OnPostStep)
                 {
                     OnPostStep(m_model, m_data);
@@ -316,8 +409,8 @@ void UMjPhysicsEngine::RunMujocoAsync()
             } // FScopeLock released here
 
             // Spin-wait for precise timing at small timesteps
-            float SpeedFactor = FMath::Clamp(SimSpeedPercent, 5.0f, 100.0f) / 100.0f;
-            double TargetTime = LoopStartTime + (TargetInterval / SpeedFactor);
+            const float SpeedFactor = FMath::Clamp(SimSpeedPercent, 5.0f, 100.0f) / 100.0f;
+            const double TargetTime = LoopStartTime + (TargetInterval / SpeedFactor);
             while (FPlatformTime::Seconds() < TargetTime)
             {
                 FPlatformProcess::YieldThread();

--- a/Source/URLab/Private/MuJoCo/Core/MjSimOptions.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjSimOptions.cpp
@@ -26,6 +26,11 @@ void FMuJoCoOptions::ApplyToSpec(mjSpec* Spec) const
 {
     if (!Spec) return;
 
+    if (bOverride_MemoryMB)
+    {
+        Spec->memory = static_cast<mjtSize>(MemoryMB) * 1024 * 1024;
+    }
+
     Spec->option.timestep = Timestep;
 
     // Gravity: UE cm/s² → MuJoCo m/s², negate Y for handedness

--- a/Source/URLab/Private/MuJoCo/Net/ZmqSensorBroadcaster.cpp
+++ b/Source/URLab/Private/MuJoCo/Net/ZmqSensorBroadcaster.cpp
@@ -31,20 +31,68 @@
 
 UZmqSensorBroadcaster::UZmqSensorBroadcaster()
 {
-	PrimaryComponentTick.bCanEverTick = false;
+	// We need a game-thread tick to build the broadcast cache lazily after all
+	// articulations have finished BeginPlay (their component lists need to be
+	// stable before we snapshot them).
+	PrimaryComponentTick.bCanEverTick = true;
 }
 
 void UZmqSensorBroadcaster::BeginPlay()
 {
 	Super::BeginPlay();
-	// ZMQ Init is deferred to the async thread
+	// ZMQ Init is deferred to the async thread. The broadcast cache is built
+	// on the first TickComponent — can't build it here because sibling
+	// articulations may not have run BeginPlay yet (actor order is undefined).
 }
 
 void UZmqSensorBroadcaster::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
+	// Make sure the physics thread stops reading our cache before we let the
+	// manager tear down the articulations.
+	bCacheBuilt.store(false, std::memory_order_release);
+	CachedRecords.Reset();
 	Super::EndPlay(EndPlayReason);
-	// Cleanup happens via ShutdownZmq called by manager, 
+	// ZMQ cleanup happens via ShutdownZmq called by manager,
 	// or in destructor if needed, but manager thread is safest.
+}
+
+void UZmqSensorBroadcaster::TickComponent(float DeltaTime, ELevelTick TickType,
+	FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+	if (!bCacheBuilt.load(std::memory_order_acquire))
+	{
+		BuildBroadcastCacheGameThread();
+	}
+}
+
+void UZmqSensorBroadcaster::BuildBroadcastCacheGameThread()
+{
+	AAMjManager* Manager = Cast<AAMjManager>(GetOwner());
+	if (!Manager) return;
+
+	TArray<AMjArticulation*> Articulations = Manager->GetAllArticulations();
+	if (Articulations.Num() == 0) return;  // wait until at least one is live
+
+	CachedRecords.Reset(Articulations.Num());
+	for (AMjArticulation* Art : Articulations)
+	{
+		if (!Art) continue;
+
+		FArticulationBroadcastRecord Rec;
+		Rec.Articulation = Art;
+		Rec.ArticPrefix  = Art->GetName();
+		Art->GetComponents<UMjComponent>(Rec.TelemetryComponents);
+		Rec.TwistCtrl    = Art->FindComponentByClass<UMjTwistController>();
+		CachedRecords.Add(MoveTemp(Rec));
+	}
+
+	// Release-store publishes the fully-populated array to the physics thread.
+	bCacheBuilt.store(true, std::memory_order_release);
+
+	UE_LOG(LogURLabNet, Log,
+		TEXT("ZmqSensorBroadcaster: built broadcast cache (%d articulations)."),
+		CachedRecords.Num());
 }
 
 void UZmqSensorBroadcaster::InitZmq()
@@ -96,68 +144,58 @@ void UZmqSensorBroadcaster::PostStep(mjModel* m, mjData* d)
 		if (!bIsInitialized) return;
 	}
 
-	AAMjManager* Manager = Cast<AAMjManager>(GetOwner());
-	if (!Manager)
+	// Acquire-load: if the game thread hasn't published the cache yet, skip
+	// this step. We DO NOT touch AActor::OwnedComponents from this thread.
+	if (!bCacheBuilt.load(std::memory_order_acquire))
 	{
-		if (bShouldLog) UE_LOG(LogURLabNet, Warning, TEXT("ZmqSensorBroadcaster: Parent is not AAMuJoCoManager!"));
 		return;
 	}
 
 	int BroadcastCount = 0;
-	TArray<AMjArticulation*> Articulations = Manager->GetAllArticulations();
 
 	if (bShouldLog)
 	{
-		UE_LOG(LogURLabNet, Log, TEXT("ZmqSensorBroadcaster PostStep: Found %d Articulations on Manager"), Articulations.Num());
+		UE_LOG(LogURLabNet, Verbose, TEXT("ZmqSensorBroadcaster PostStep: broadcasting %d cached articulations"),
+			CachedRecords.Num());
 	}
 
-	for (AMjArticulation* Articulation : Articulations)
+	for (const FArticulationBroadcastRecord& Rec : CachedRecords)
 	{
-		if (!Articulation) continue;
-		FString ArticPrefix = Articulation->GetName();
+		if (!Rec.Articulation) continue;
 
-		// Get all components that can serialize telemetry
-		TArray<UMjComponent*> Components;
-		Articulation->GetComponents<UMjComponent>(Components);
-
-		for (UMjComponent* Comp : Components)
+		for (UMjComponent* Comp : Rec.TelemetryComponents)
 		{
-			if (Comp->bIsDefault) continue;
+			if (!Comp || Comp->bIsDefault) continue;
 
 			FString TopicSuffix = Comp->GetTelemetryTopicName();
 			if (TopicSuffix.IsEmpty()) continue;
 
-			FString FullTopic = FString::Printf(TEXT("%s/%s"), *ArticPrefix, *TopicSuffix);
+			FString FullTopic = FString::Printf(TEXT("%s/%s"), *Rec.ArticPrefix, *TopicSuffix);
 
 			FBufferArchive Payload;
 			Comp->BuildBinaryPayload(Payload);
 
 			if (Payload.Num() > 0)
 			{
-				// Send Topic (ZMQ_SNDMORE)
 				zmq_send(ZmqPublisher, TCHAR_TO_UTF8(*FullTopic), FullTopic.Len(), ZMQ_SNDMORE);
-				// Send Binary Payload
 				zmq_send(ZmqPublisher, Payload.GetData(), Payload.Num(), 0);
 				BroadcastCount++;
 			}
 		}
 
-		// Broadcast twist commands if a TwistController is present
-		UMjTwistController* TwistCtrl = Articulation->FindComponentByClass<UMjTwistController>();
-		if (TwistCtrl)
+		if (Rec.TwistCtrl)
 		{
-			FVector Twist = TwistCtrl->GetTwist();
-			FString TwistTopic = FString::Printf(TEXT("%s/twist"), *ArticPrefix);
+			FVector Twist = Rec.TwistCtrl->GetTwist();
+			FString TwistTopic = FString::Printf(TEXT("%s/twist"), *Rec.ArticPrefix);
 			float TwistData[3] = { (float)Twist.X, (float)Twist.Y, (float)Twist.Z };
 			zmq_send(ZmqPublisher, TCHAR_TO_UTF8(*TwistTopic), TwistTopic.Len(), ZMQ_SNDMORE);
 			zmq_send(ZmqPublisher, TwistData, sizeof(TwistData), 0);
 			BroadcastCount++;
 
-			// Broadcast action bitmask if any keys are pressed
-			int32 Actions = TwistCtrl->GetActiveActions();
+			int32 Actions = Rec.TwistCtrl->GetActiveActions();
 			if (Actions != 0)
 			{
-				FString ActionTopic = FString::Printf(TEXT("%s/actions"), *ArticPrefix);
+				FString ActionTopic = FString::Printf(TEXT("%s/actions"), *Rec.ArticPrefix);
 				zmq_send(ZmqPublisher, TCHAR_TO_UTF8(*ActionTopic), ActionTopic.Len(), ZMQ_SNDMORE);
 				zmq_send(ZmqPublisher, &Actions, sizeof(Actions), 0);
 				BroadcastCount++;
@@ -171,6 +209,6 @@ void UZmqSensorBroadcaster::PostStep(mjModel* m, mjData* d)
 	}
 	else if (bShouldLog)
 	{
-		UE_LOG(LogURLabNet, Log, TEXT("ZmqSensorBroadcaster: successfully broadcast %d messages to ZMQ."), BroadcastCount);
+		UE_LOG(LogURLabNet, Verbose, TEXT("ZmqSensorBroadcaster: successfully broadcast %d messages to ZMQ."), BroadcastCount);
 	}
 }

--- a/Source/URLab/Public/MuJoCo/Components/Deformable/MjFlexcomp.h
+++ b/Source/URLab/Public/MuJoCo/Components/Deformable/MjFlexcomp.h
@@ -185,6 +185,33 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Contact", meta=(EditCondition="bOverride_Internal"))
     bool bInternal = false;
 
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Contact", meta=(InlineEditConditionToggle))
+    bool bOverride_Friction = false;
+
+    /** Contact friction: {tangential, torsional, rolling}. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Contact", meta=(EditCondition="bOverride_Friction"))
+    TArray<float> Friction;
+
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Contact", meta=(InlineEditConditionToggle))
+    bool bOverride_SolMix = false;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Contact", meta=(EditCondition="bOverride_SolMix"))
+    float SolMix = 1.0f;
+
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Contact", meta=(InlineEditConditionToggle))
+    bool bOverride_ContactSolRef = false;
+
+    /** Contact solref: {time_constant, damping_ratio}. Leave empty for MuJoCo defaults. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Contact", meta=(EditCondition="bOverride_ContactSolRef"))
+    TArray<float> ContactSolRef;
+
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Contact", meta=(InlineEditConditionToggle))
+    bool bOverride_ContactSolImp = false;
+
+    /** Contact solimp: 5-element impedance vector. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Contact", meta=(EditCondition="bOverride_ContactSolImp"))
+    TArray<float> ContactSolImp;
+
     // --- Edge Properties ---
 
     UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Edge", meta=(InlineEditConditionToggle))
@@ -198,6 +225,27 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Edge", meta=(EditCondition="bOverride_EdgeDamping"))
     float EdgeDamping = 0.0f;
+
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Edge", meta=(InlineEditConditionToggle))
+    bool bOverride_EdgeEquality = false;
+
+    /** Emit equality constraints per edge. Pairs with EdgeSolRef/EdgeSolImp. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Edge", meta=(EditCondition="bOverride_EdgeEquality"))
+    bool bEdgeEquality = false;
+
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Edge", meta=(InlineEditConditionToggle))
+    bool bOverride_EdgeSolRef = false;
+
+    /** Edge solref: {time_constant, damping_ratio}. Only has effect when bEdgeEquality=true. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Edge", meta=(EditCondition="bOverride_EdgeSolRef"))
+    TArray<float> EdgeSolRef;
+
+    UPROPERTY(EditAnywhere, Category = "MuJoCo|Flexcomp|Edge", meta=(InlineEditConditionToggle))
+    bool bOverride_EdgeSolImp = false;
+
+    /** Edge solimp: 5-element impedance vector. Only has effect when bEdgeEquality=true. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo|Flexcomp|Edge", meta=(EditCondition="bOverride_EdgeSolImp"))
+    TArray<float> EdgeSolImp;
 
     // --- Elasticity Properties ---
 

--- a/Source/URLab/Public/MuJoCo/Core/MjArticulation.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjArticulation.h
@@ -396,6 +396,13 @@ protected:
     TMap<int32, UMjTendon*>   TendonIdMap;
     TMap<int32, UMjActuator*> ActuatorIdMap;
 
+    /** Controller cached at PostSetup (game thread) so ApplyControls can
+     *  read it from the physics thread without iterating OwnedComponents —
+     *  that iteration races against game-thread component mutations (e.g.
+     *  the auto-created UMjTwistController) and corrupts nearby heap state. */
+    UPROPERTY(Transient)
+    class UMjArticulationController* CachedController = nullptr;
+
 public:    
     virtual void Tick(float DeltaTime) override;
 

--- a/Source/URLab/Public/MuJoCo/Core/MjSimOptions.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjSimOptions.h
@@ -74,6 +74,15 @@ struct URLAB_API FMuJoCoOptions
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo Options", meta=(EditCondition="bOverride_Timestep"))
     float Timestep = 0.002f;
 
+    UPROPERTY(EditAnywhere, Category = "MuJoCo Options", meta=(InlineEditConditionToggle))
+    bool bOverride_MemoryMB = false;
+
+    /** @brief MuJoCo spec-level arena size in megabytes. Maps to
+     *  applied pre-compile (the unified arena is sized at mjData creation). */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MuJoCo Options",
+        meta=(EditCondition="bOverride_MemoryMB", ClampMin="1"))
+    int32 MemoryMB = 100;
+
     // --- Physics Environment ---
 
     UPROPERTY(EditAnywhere, Category = "MuJoCo Options", meta=(InlineEditConditionToggle))

--- a/Source/URLab/Public/MuJoCo/Net/ZmqSensorBroadcaster.h
+++ b/Source/URLab/Public/MuJoCo/Net/ZmqSensorBroadcaster.h
@@ -22,20 +22,30 @@
 
 #pragma once
 
+#include <atomic>
+
 #include "CoreMinimal.h"
 #include "MuJoCo/Net/MjZmqComponent.h"
 #include "ZmqSensorBroadcaster.generated.h"
+
+class AMjArticulation;
+class UMjComponent;
+class UMjTwistController;
 
 UCLASS( ClassGroup=(Custom), meta=(BlueprintSpawnableComponent) )
 class URLAB_API UZmqSensorBroadcaster : public UMjZmqComponent
 {
 	GENERATED_BODY()
 
-public:	
+public:
 	UZmqSensorBroadcaster();
 
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+	/** Game-thread tick: builds the broadcast cache lazily. */
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
+		FActorComponentTickFunction* ThisTickFunction) override;
 
 	// ZMQ Settings
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ZMQ")
@@ -45,9 +55,34 @@ public:
 	virtual void InitZmq() override;
 	virtual void ShutdownZmq() override;
 	virtual void PostStep(mjModel* m, mjData* d) override;
-    
+
 private:
 	void* ZmqContext = nullptr;
 	void* ZmqPublisher = nullptr;
 	int32 FrameCounter = 0;
+
+	/** Per-articulation snapshot built once on the game thread and read
+	 *  repeatedly from the physics thread in PostStep. Iterating
+	 *  OwnedComponents on the physics thread is unsafe (the game thread
+	 *  can mutate it during actor BeginPlay — e.g. auto-created twist
+	 *  controllers), and tripping the sparse-array range-for ensure
+	 *  corrupts nearby heap state, producing seemingly-unrelated RHI
+	 *  crashes further along. */
+	struct FArticulationBroadcastRecord
+	{
+		AMjArticulation* Articulation = nullptr;
+		FString ArticPrefix;
+		TArray<UMjComponent*> TelemetryComponents;
+		UMjTwistController* TwistCtrl = nullptr;
+	};
+
+	/** Populated once on the game thread. bCacheBuilt (with acquire/release
+	 *  ordering) publishes visibility to the physics thread. No mid-play
+	 *  refresh — broadcaster assumes articulations and their components are
+	 *  stable across a single play session. */
+	TArray<FArticulationBroadcastRecord> CachedRecords;
+	std::atomic<bool> bCacheBuilt { false };
+
+	/** Game-thread-only: enumerate articulations + components into CachedRecords. */
+	void BuildBroadcastCacheGameThread();
 };


### PR DESCRIPTION
## Summary

- **Flex crash fix.** Install `mju_user_error`/`mju_user_warning` on `UMjPhysicsEngine` so MuJoCo's fatal path logs via `UE_LOG` instead of `exit(1)`. Prevents CRT unwind from tripping live `FRHIBreadcrumbEventManual` destructor assertions on other threads. Root cause (MuJoCo's `mj_sleep` invariant under SLEEP + MULTICCD + flex + free-body) is upstream — this contains the blast.
- **Physics-thread races.** Cache articulation controller in `PostSetup` (not per-step `FindComponentByClass`). Build `ZmqSensorBroadcaster` cache on game thread, publish atomically.
- **EndPlay safety.** Bound async-thread wait to 3 s so a stuck `mj_step` can't freeze PIE-stop.
- **Camera cleanup.** Drop redundant per-tick `CaptureScene()` — `bCaptureEveryFrame` already handles it; the extra call was doubling RHI submission and triggering UE's "major inefficiency" warning.
- **Flex authoring.** New contact `friction`/`solmix`/`solref`/`solimp` and edge `equality`/`solref`/`solimp` UPROPERTYs. New `FMuJoCoOptions::MemoryMB` knob.

## Test plan

- [x] Flex + SLEEP + MULTICCD + free body: editor no longer crashes; throttled ``[MuJoCo fatal] mj_sleep: ...`` lines in log.
- [x] ``Scripts/build_and_test.sh`` — 175/175 pass (see evidence below).
- [x] ``uv run src/run.py --test --prefix <p>`` on [URLab_Bridge](https://github.com/URLab-Sim/urlab_bridge) receives joint state cleanly.
- [x] PIE-stop on stuck ``mj_step`` exits within ~3 s, not hangs.

## Build + Test Evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-20 19:41:12 UTC
Host      : buzz-main
Git HEAD  : 965ad087 (fix/runtime-bugfixes)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : /tmp/urlab_test.log  (sha256: 00f0c25ef87f979f)
================================
```