### PR TITLE
Fix the options not being propagated

### DIFF
--- a/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
@@ -204,6 +204,14 @@ void UMjPhysicsEngine::Compile()
 {
     PreCompile();
 
+    // mjs_attach merges the body tree but silently drops the child spec's
+    // option block. Apply the articulation's SimOptions (parsed from the XML's
+    // <option> tag) directly to the root spec so they are baked into the model.
+    if (m_articulations.Num() > 0 && m_articulations[0])
+    {
+        m_articulations[0]->SimOptions.ApplyToSpec(m_spec);
+    }
+
     UE_LOG(LogURLab, Log, TEXT("Compiling MuJoCo model"));
     m_LastCompileError.Empty();
     m_model = mj_compile(m_spec, &m_vfs);


### PR DESCRIPTION
## Summary

Make options specified in the model XML be actually propagated to the compiled XML.

This was primarily written by Claude.

## Motivation

Some models set options, such as impratio, that materially affect the simulation quality. This change lets the models work exactly as they do in the mujoco viewer without using the manager to override those options.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-21 00:04:42 UTC
Host      : instance-3
Git HEAD  : a7eb0532 (fix_option_propagation)
Engine    : C:\Program Files\Epic Games\UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : REDACTED
```

## Manual verification steps

1. Replace the mujoco menagerie's arx_l5 xml with the [attached](https://github.com/user-attachments/files/26922713/arx_l5.xml) version (it adds two extra cubes)
2. Add the xml to a project with some sort of ground plane
3. Try to grab the boxes with the arm, they will slide out without this change (because the impratio is ignored)

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes
- [x] Docs updated for user-facing changes
