### PR TITLE
Explicitly load filetype plugins.

### DIFF
--- a/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
@@ -33,6 +33,7 @@
 #include "XmlFile.h"
 #include "Internationalization/Regex.h"
 #include "Utils/URLabLogging.h"
+#include "Interfaces/IPluginManager.h"
 #include <atomic>
 #if WITH_EDITOR
 #include "Misc/MessageDialog.h"
@@ -127,6 +128,31 @@ static void URLab_InstallMujocoCallbacks()
     if (PErr)  { *PErr  = &URLab_OnMujocoError;   }
     if (PWarn) { *PWarn = &URLab_OnMujocoWarning; }
     UE_LOG(LogURLab, Log, TEXT("[URLab] MuJoCo error callbacks installed (err=%p warn=%p)"), (void*)PErr, (void*)PWarn);
+
+    // MuJoCo ships OBJ and STL mesh decoding as separate mjpDecoder plugin DLLs
+    // (obj_decoder.dll, stl_decoder.dll) rather than building them into the core.
+    // Plugin DLLs must be loaded explicitly via mj_loadPluginLibrary (API added in
+    // MuJoCo 2.3.1) before any mj_compile call — without this, the codec registry
+    // is empty and mj_compile reports "no decoder found".
+    FString BinDir = IPluginManager::Get().FindPlugin(TEXT("UnrealRoboticsLab"))->GetBaseDir();
+    BinDir = FPaths::Combine(BinDir, TEXT("Binaries/Win64"));
+    BinDir = FPaths::ConvertRelativePathToFull(BinDir);
+
+    TArray<FString> CodecDlls = { TEXT("obj_decoder.dll"), TEXT("stl_decoder.dll") };
+    for (const FString& Dll : CodecDlls)
+    {
+        FString DllPath = FPaths::Combine(BinDir, Dll);
+        if (FPaths::FileExists(DllPath))
+        {
+            mj_loadPluginLibrary(TCHAR_TO_UTF8(*DllPath));
+            UE_LOG(LogURLab, Log, TEXT("[URLab] Loaded MuJoCo codec plugin %s"), *Dll);
+        }
+        else
+        {
+            UE_LOG(LogURLab, Warning, TEXT("[URLab] MuJoCo codec plugin not found: %s"), *DllPath);
+        }
+    }
+
     GMujocoCallbacksInstalled = true;
 }
 


### PR DESCRIPTION
## Summary

- Add explicit plugin dll loading for obj/stl loaders

This was primarily written by Claude.

## Motivation

Without this change, no models with obj files would load for me.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-21 00:12:01 UTC
Host      : instance-3
Git HEAD  : 5bc293fd (obj_plugins)
Engine    : C:\Program Files\Epic Games\UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : REDACTED
================================
```

## Manual verification steps

Try adding the arx_l5 model to a UE project, without this change it will fail XML verification due to being unable to load obj file.s

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes
- [x] Docs updated for user-facing changes
