### PR TITLE
Improve build_and_test.ps1 for better path support

### DIFF
--- a/Scripts/build_and_test.ps1
+++ b/Scripts/build_and_test.ps1
@@ -22,7 +22,7 @@
 
 <#
 .SYNOPSIS
-    Build url_projEditor and run the URLab automation suite, then print a
+    Build the project's Editor target and run the URLab automation suite, then print a
     machine-identifiable summary block to paste into a PR.
 
 .EXAMPLE
@@ -38,17 +38,16 @@
 param(
     [Parameter(Mandatory = $true)] [string] $Engine,
     [Parameter(Mandatory = $true)] [string] $Project,
-    [string] $Target = 'url_projEditor',
     [string] $Filter = 'URLab',
     [string] $Log    = (Join-Path $env:TEMP 'urlab_test.log')
 )
 
 $ErrorActionPreference = 'Stop'
 
-$ubt = Join-Path $Engine 'Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe'
+$bat = Join-Path $Engine 'Engine\Build\BatchFiles\Build.bat'
 $cmd = Join-Path $Engine 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
 
-if (-not (Test-Path $ubt)) { Write-Error "UBT not found: $ubt";                exit 3 }
+if (-not (Test-Path $bat)) { Write-Error "Build.bat not found: $bat";          exit 3 }
 if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   exit 3 }
 
 # Truncate the test log up-front so a build failure (or any early exit
@@ -57,9 +56,9 @@ if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   e
 Set-Content -Path $Log -Value '' -NoNewline
 
 # --- Build -----------------------------------------------------------------
-Write-Host ">>> Building $Target (Win64 Development)..."
-$buildArgs = @($Target, 'Win64', 'Development', "-Project=$Project", '-WaitMutex')
-$buildOut  = & $ubt @buildArgs 2>&1
+Write-Host ">>> Building UnrealEditor (Win64 Development, project=$Project)..."
+$buildArgs = @('UnrealEditor', 'Win64', 'Development', "-Project=$Project", '-TargetType=Editor', '-Progress')
+$buildOut  = & $bat @buildArgs 2>&1
 $buildOut | Select-Object -Last 10 | ForEach-Object { Write-Host $_ }
 $buildStatus = if ($buildOut -match 'Result: Succeeded') { 'Succeeded' } else { 'Failed' }
 


### PR DESCRIPTION
## Summary

- Use Build.bat which has better support for spaces in paths/editor targets.

This was written primarily by Claude.

## Motivation

The script wasn't working for my project path. The removal of the -Target arg also simplifies the invocation,

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-21 00:30:21 UTC
Host      : instance-3
Git HEAD  : 31ddf169 (fix_test_script)
Engine    : C:\Program Files\Epic Games\UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : C:\Users\smile\AppData\Local\Temp\2\urlab_test.log  (sha256: 22a428c57b283b7d)
================================
```

## Manual verification steps

- Make a project in a path with a space in it
- Without this change it'll fail in weird ways

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes
- [x] Docs updated for user-facing changes
