### PR TITLE
Detect stale MuJoCo install at build time; wipe install/<dep>/ on rebuild

### DIFF
--- a/Source/URLab/URLab.Build.cs
+++ b/Source/URLab/URLab.Build.cs
@@ -4,6 +4,7 @@
 using System;
 using UnrealBuildTool;
 using System.IO;
+using System.Text.RegularExpressions;
 
 public class URLab : ModuleRules
 {
@@ -176,9 +177,51 @@ public class URLab : ModuleRules
 		}
 	}
 
+	// Pinned MuJoCo version. Bump in lockstep with $PinnedCommit in
+	// third_party/MuJoCo/build.ps1 / build.sh and the matching constant
+	// in src/include/mujoco/mujoco.h's mjVERSION_HEADER.
+	private const int ExpectedMjVersionHeader = 3007000;  // MuJoCo 3.7.0
+
 	protected void AddMuj(ReadOnlyTargetRules Target)
 	{
+		VerifyMuJoCoInstall();
 		AddThirdPartyLibrary("MuJoCo", Target);
+	}
+
+	// Reads the installed mujoco.h and verifies its mjVERSION_HEADER matches
+	// what URLab was bumped to. Catches the common "I git-pulled URLab but
+	// forgot to re-run third_party/MuJoCo/build.ps1" failure mode before any
+	// code compiles, with a message that says exactly what to do.
+	private void VerifyMuJoCoInstall()
+	{
+		string MjHeader = Path.Combine(ThirdPartyPath, "MuJoCo", "include", "mujoco", "mujoco.h");
+		if (!File.Exists(MjHeader))
+		{
+			throw new BuildException(
+				"MuJoCo headers missing at '{0}'. Run third_party/MuJoCo/build.ps1 (Windows) " +
+				"or third_party/MuJoCo/build.sh (Linux/macOS) to build the dependency, then retry.",
+				MjHeader);
+		}
+
+		string Text = File.ReadAllText(MjHeader);
+		Match M = Regex.Match(Text, @"#define\s+mjVERSION_HEADER\s+(\d+)");
+		if (!M.Success)
+		{
+			throw new BuildException(
+				"Could not parse mjVERSION_HEADER from '{0}'. The header may be corrupt — " +
+				"wipe third_party/install/MuJoCo/ and re-run third_party/MuJoCo/build.ps1.",
+				MjHeader);
+		}
+
+		int InstalledVersion = int.Parse(M.Groups[1].Value);
+		if (InstalledVersion != ExpectedMjVersionHeader)
+		{
+			throw new BuildException(
+				"MuJoCo install at '{0}' is at version {1}; URLab expects {2}. " +
+				"Wipe third_party/install/MuJoCo/ and third_party/MuJoCo/src/build/, " +
+				"then re-run third_party/MuJoCo/build.ps1 (Windows) or build.sh (Linux/macOS).",
+				Path.Combine(ThirdPartyPath, "MuJoCo"), InstalledVersion, ExpectedMjVersionHeader);
+		}
 	}
 
 	protected void AddCoACD(ReadOnlyTargetRules Target)

--- a/third_party/CoACD/build.ps1
+++ b/third_party/CoACD/build.ps1
@@ -14,6 +14,13 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
+# Wipe any prior install of THIS package only — cmake --install is additive
+# and would otherwise leave stale files behind across version bumps.
+if (Test-Path $InstallDir) {
+    Write-Host "Removing previous install at $InstallDir" -ForegroundColor Gray
+    Remove-Item -Recurse -Force $InstallDir
+}
+
 $PinnedCommit = "c7436bf"  # Pin to tested commit (CDT include path fix + unbundled 3rd party support)
 
 $RepoDir = "src"

--- a/third_party/CoACD/build.sh
+++ b/third_party/CoACD/build.sh
@@ -3,6 +3,17 @@ INSTALL_DIR=${1:-"../install"}
 BUILD_TYPE=${2:-"Release"}
 PINNED_COMMIT="c7436bf"  # Pin to tested commit (CDT include path fix + unbundled 3rd party support)
 
+# Resolve INSTALL_DIR to an absolute per-package path. URLab.Build.cs expects
+# headers/libs/dlls under install/<dep>/, matching the .ps1 layout.
+INSTALL_DIR="$(cd "$(dirname "$INSTALL_DIR")" && pwd)/$(basename "$INSTALL_DIR")/CoACD"
+
+# Wipe any prior install of THIS package only — cmake --install is additive
+# and would otherwise leave stale files behind across version bumps.
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Removing previous install at $INSTALL_DIR"
+    rm -rf "$INSTALL_DIR"
+fi
+
 REPO_DIR="src"
 if [ ! -d "$REPO_DIR" ]; then
     echo "Cloning CoACD (pinned: $PINNED_COMMIT)..."

--- a/third_party/MuJoCo/build.ps1
+++ b/third_party/MuJoCo/build.ps1
@@ -14,6 +14,16 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
+# Wipe any prior install of THIS package only. cmake --install is additive and
+# leaves stale files behind when the upstream stops producing them — e.g. the
+# MuJoCo 3.7.0 bump statically linked obj_decoder/stl_decoder into mujoco.dll
+# but additive installs over a 3.6.x tree left the old plugin DLLs in bin/,
+# silently breaking OBJ loading until they were manually removed.
+if (Test-Path $InstallDir) {
+    Write-Host "Removing previous install at $InstallDir" -ForegroundColor Gray
+    Remove-Item -Recurse -Force $InstallDir
+}
+
 $PinnedCommit = "72cb2b210da6"  # Pin to MuJoCo 3.7.0 release (2026-04-14)
 
 $RepoDir = "src"

--- a/third_party/MuJoCo/build.sh
+++ b/third_party/MuJoCo/build.sh
@@ -3,6 +3,20 @@ INSTALL_DIR=${1:-"../install"}
 BUILD_TYPE=${2:-"Release"}
 PINNED_COMMIT="47264877"  # Pin to tested commit (MuJoCo 3.7.0 dev, polynomial stiffness/damping)
 
+# Resolve INSTALL_DIR to an absolute per-package path. URLab.Build.cs expects
+# headers/libs/dlls under install/<dep>/, matching the .ps1 layout.
+INSTALL_DIR="$(cd "$(dirname "$INSTALL_DIR")" && pwd)/$(basename "$INSTALL_DIR")/MuJoCo"
+
+# Wipe any prior install of THIS package only. cmake --install is additive and
+# leaves stale files behind across version bumps — e.g. the MuJoCo 3.7.0 bump
+# statically linked obj_decoder/stl_decoder into mujoco.dll, but additive
+# installs over a 3.6.x tree left the old plugin DLLs in bin/, silently
+# breaking OBJ loading until they were manually removed.
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Removing previous install at $INSTALL_DIR"
+    rm -rf "$INSTALL_DIR"
+fi
+
 REPO_DIR="src"
 if [ ! -d "$REPO_DIR" ]; then
     echo "Cloning MuJoCo (pinned: $PINNED_COMMIT)..."

--- a/third_party/libzmq/build.ps1
+++ b/third_party/libzmq/build.ps1
@@ -14,6 +14,13 @@ $InstallDir = $InstallDir.Replace('\', '/')
 Write-Host "Resolved InstallDir: $InstallDir" -ForegroundColor Gray
 Write-Host "Resolved BuildType: $BuildType" -ForegroundColor Gray
 
+# Wipe any prior install of THIS package only — cmake --install is additive
+# and would otherwise leave stale files behind across version bumps.
+if (Test-Path $InstallDir) {
+    Write-Host "Removing previous install at $InstallDir" -ForegroundColor Gray
+    Remove-Item -Recurse -Force $InstallDir
+}
+
 $PinnedCommit = "7d95ac02"  # Pin to tested commit (v4.3.5+)
 
 $RepoDir = "src"

--- a/third_party/libzmq/build.sh
+++ b/third_party/libzmq/build.sh
@@ -3,6 +3,17 @@ INSTALL_DIR=${1:-"../install"}
 BUILD_TYPE=${2:-"Release"}
 PINNED_COMMIT="7d95ac02"  # Pin to tested commit (v4.3.5+)
 
+# Resolve INSTALL_DIR to an absolute per-package path. URLab.Build.cs expects
+# headers/libs/dlls under install/<dep>/, matching the .ps1 layout.
+INSTALL_DIR="$(cd "$(dirname "$INSTALL_DIR")" && pwd)/$(basename "$INSTALL_DIR")/libzmq"
+
+# Wipe any prior install of THIS package only — cmake --install is additive
+# and would otherwise leave stale files behind across version bumps.
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Removing previous install at $INSTALL_DIR"
+    rm -rf "$INSTALL_DIR"
+fi
+
 REPO_DIR="src"
 if [ ! -d "$REPO_DIR" ]; then
     echo "Cloning libzmq (pinned: $PINNED_COMMIT)..."


### PR DESCRIPTION
## Summary

Two related fixes for the stale-third-party-install class of bug surfaced in #35:

- **`URLab.Build.cs`** now reads `third_party/install/MuJoCo/include/mujoco/mujoco.h`, parses `mjVERSION_HEADER`, and throws a `BuildException` if it doesn't match the pinned constant (`3007000` / 3.7.0). Catches the "git-pulled URLab but forgot to re-run `third_party/MuJoCo/build.ps1`" failure mode before any code compiles, with a message that says exactly what to do.
- **Each `third_party/<dep>/build.{ps1,sh}`** now wipes `install/<dep>/` at the top of the script. `cmake --install` is additive — without this, a version bump that stops producing a previously-installed file leaves the old file behind silently. That's exactly how stale `obj_decoder.dll` / `stl_decoder.dll` from a pre-3.7.0 build were left in `bin/` masking the OBJ-loading regression in #35.

The bash scripts also got a fix to install into `install/<dep>/` rather than `install/` directly — they previously didn't append the package name (Windows `.ps1` already did), which would have caused inter-package collisions on Linux. URLab.Build.cs always expected the per-package layout on both platforms.

## Test plan

- [x] `Scripts/build_and_test.sh` — 175/175 pass (current install matches expected version, check is silent on success).
- [x] Manual: temporarily set `ExpectedMjVersionHeader = 3008000` in Build.cs → next compile errors with the helpful message.
- [x] Manual: nuke `third_party/install/MuJoCo/` then run `build.ps1` → wipe step is a no-op on first run; second run with stale leftovers cleans them.

## Build + Test Evidence

```
=== URLab build+test summary ===
Timestamp : 2026-04-21 07:09:30 UTC
Host      : buzz-main
Git HEAD  : a87e43b8 (fix/third-party-stale-install)
Engine    : /c/Program Files/Epic Games/UE_5.7
Build     : Succeeded
Tests     : 175 / 175 passed (0 failed)  [175 tests performed]
Log       : /tmp/urlab_test.log  (sha256: d9cdb123847439d5)
================================
```
