### PR TITLE
Harden build+test summary: scrub host/paths, add dep SHAs, derive target

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,12 +41,12 @@ mutex and the cmd-line tester silently returns an empty log.
 ```
 === URLab build+test summary ===
 Timestamp : <UTC>
-Host      : <machine>
 Git HEAD  : <short-sha> (<branch>)
-Engine    : <engine root>
+Engine    : <UE_X.Y>
+Deps      : mj=<sha7> coacd=<sha7> zmq=<sha7>
 Build     : <Succeeded|Failed>
 Tests     : <pass> / <total> passed (<fail> failed)
-Log       : <path>  (sha256: <hash>)
+Log sha256: <hash>
 ================================
 ```
 

--- a/Scripts/build_and_test.ps1
+++ b/Scripts/build_and_test.ps1
@@ -22,7 +22,7 @@
 
 <#
 .SYNOPSIS
-    Build url_projEditor and run the URLab automation suite, then print a
+    Build the project's Editor target and run the URLab automation suite, then print a
     machine-identifiable summary block to paste into a PR.
 
 .EXAMPLE
@@ -38,17 +38,16 @@
 param(
     [Parameter(Mandatory = $true)] [string] $Engine,
     [Parameter(Mandatory = $true)] [string] $Project,
-    [string] $Target = 'url_projEditor',
     [string] $Filter = 'URLab',
     [string] $Log    = (Join-Path $env:TEMP 'urlab_test.log')
 )
 
 $ErrorActionPreference = 'Stop'
 
-$ubt = Join-Path $Engine 'Engine\Binaries\DotNET\UnrealBuildTool\UnrealBuildTool.exe'
+$bat = Join-Path $Engine 'Engine\Build\BatchFiles\Build.bat'
 $cmd = Join-Path $Engine 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
 
-if (-not (Test-Path $ubt)) { Write-Error "UBT not found: $ubt";                exit 3 }
+if (-not (Test-Path $bat)) { Write-Error "Build.bat not found: $bat";          exit 3 }
 if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   exit 3 }
 
 # Truncate the test log up-front so a build failure (or any early exit
@@ -57,9 +56,9 @@ if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   e
 Set-Content -Path $Log -Value '' -NoNewline
 
 # --- Build -----------------------------------------------------------------
-Write-Host ">>> Building $Target (Win64 Development)..."
-$buildArgs = @($Target, 'Win64', 'Development', "-Project=$Project", '-WaitMutex')
-$buildOut  = & $ubt @buildArgs 2>&1
+Write-Host ">>> Building UnrealEditor (Win64 Development, project=$Project)..."
+$buildArgs = @('UnrealEditor', 'Win64', 'Development', "-Project=$Project", '-TargetType=Editor', '-Progress')
+$buildOut  = & $bat @buildArgs 2>&1
 $buildOut | Select-Object -Last 10 | ForEach-Object { Write-Host $_ }
 $buildStatus = if ($buildOut -match 'Result: Succeeded') { 'Succeeded' } else { 'Failed' }
 

--- a/Scripts/build_and_test.ps1
+++ b/Scripts/build_and_test.ps1
@@ -30,6 +30,14 @@
         -Engine  'C:\Program Files\Epic Games\UE_5.7' `
         -Project 'C:\path\to\your.uproject'
 
+.EXAMPLE
+    # Override the editor target only if your project doesn't follow UE's
+    # <ProjectName>Editor convention.
+    .\Scripts\build_and_test.ps1 `
+        -Engine  'C:\Program Files\Epic Games\UE_5.7' `
+        -Project 'C:\MyGame\MyGame.uproject' `
+        -Target  CustomEditorTargetName
+
 .NOTES
     Exit codes: 0 ok, 1 build failed, 2 tests failed, 3 bad args.
 #>
@@ -38,11 +46,19 @@
 param(
     [Parameter(Mandatory = $true)] [string] $Engine,
     [Parameter(Mandatory = $true)] [string] $Project,
+    [string] $Target = '',
     [string] $Filter = 'URLab',
     [string] $Log    = (Join-Path $env:TEMP 'urlab_test.log')
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Derive the editor target from the .uproject filename if not explicitly
+# supplied. UE's convention is <ProjectName>Editor - e.g. MyGame.uproject ->
+# MyGameEditor. Override with -Target for projects that don't follow this.
+if ([string]::IsNullOrWhiteSpace($Target)) {
+    $Target = [System.IO.Path]::GetFileNameWithoutExtension($Project) + 'Editor'
+}
 
 $bat = Join-Path $Engine 'Engine\Build\BatchFiles\Build.bat'
 $cmd = Join-Path $Engine 'Engine\Binaries\Win64\UnrealEditor-Cmd.exe'
@@ -56,8 +72,11 @@ if (-not (Test-Path $cmd)) { Write-Error "UnrealEditor-Cmd not found: $cmd";   e
 Set-Content -Path $Log -Value '' -NoNewline
 
 # --- Build -----------------------------------------------------------------
-Write-Host ">>> Building UnrealEditor (Win64 Development, project=$Project)..."
-$buildArgs = @('UnrealEditor', 'Win64', 'Development', "-Project=$Project", '-TargetType=Editor', '-Progress')
+Write-Host ">>> Building $Target (Win64 Development)..."
+# Note: -TargetType=Editor is intentionally omitted. Combined with a positional
+# target name it makes UBT's two action-graph passes ambiguous and bails with
+# Result: Failed (ActionGraphInvalid). Just the positional target is enough.
+$buildArgs = @($Target, 'Win64', 'Development', "-Project=$Project", '-Progress')
 $buildOut  = & $bat @buildArgs 2>&1
 $buildOut | Select-Object -Last 10 | ForEach-Object { Write-Host $_ }
 $buildStatus = if ($buildOut -match 'Result: Succeeded') { 'Succeeded' } else { 'Failed' }
@@ -91,12 +110,39 @@ if ($buildStatus -eq 'Succeeded') {
 }
 
 # --- Fingerprint + summary -------------------------------------------------
+# Note: Host and Log-path lines are intentionally omitted from the summary
+# block because they leak the reporter's hostname / Windows username on local
+# runs. The SHA-256 of the log is sufficient for reviewers to verify content
+# integrity when they re-run the suite themselves (#37).
 $ts        = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd HH:mm:ss') + ' UTC'
-$hostName  = [System.Net.Dns]::GetHostName()
 try {
     $gitSha    = (git rev-parse --short=8 HEAD 2>$null).Trim()
     $gitBranch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim()
 } catch { $gitSha = 'unknown'; $gitBranch = 'unknown' }
+
+# Strip the engine path down to its last segment (e.g. 'UE_5.7'). The full
+# path can contain the user's install root on a non-standard layout.
+$engineLabel = Split-Path -Leaf $Engine
+if ([string]::IsNullOrWhiteSpace($engineLabel)) { $engineLabel = $Engine }
+
+# Third-party dep SHAs — pulls from third_party/install/<dep>/INSTALLED_SHA.txt
+# (written by the CMake build scripts). Lets a reviewer verify they're
+# comparing against the same binary toolchain. Silent skip if missing.
+$pluginRoot = Split-Path -Parent $PSScriptRoot
+$depsLine = ''
+foreach ($kv in @(@{name='mj';  dir='MuJoCo'},
+                  @{name='coacd'; dir='CoACD'},
+                  @{name='zmq'; dir='libzmq'})) {
+    $shaPath = Join-Path $pluginRoot ('third_party/install/' + $kv.dir + '/INSTALLED_SHA.txt')
+    if (Test-Path $shaPath) {
+        $sha = (Get-Content $shaPath -Raw).Trim()
+        if ($sha.Length -ge 7) {
+            if ($depsLine) { $depsLine += ' ' }
+            $depsLine += ('{0}={1}' -f $kv.name, $sha.Substring(0, 7))
+        }
+    }
+}
+if ([string]::IsNullOrWhiteSpace($depsLine)) { $depsLine = 'unavailable' }
 
 $logHash = 'n/a'
 if ((Test-Path $Log) -and (Get-Item $Log).Length -gt 0) {
@@ -109,12 +155,12 @@ if ($testsPerformed) { $testsLine += '  [' + $testsPerformed + ']' }
 Write-Host ''
 Write-Host '=== URLab build+test summary ==='
 Write-Host ('Timestamp : ' + $ts)
-Write-Host ('Host      : ' + $hostName)
 Write-Host ('Git HEAD  : {0} ({1})' -f $gitSha, $gitBranch)
-Write-Host ('Engine    : ' + $Engine)
+Write-Host ('Engine    : ' + $engineLabel)
+Write-Host ('Deps      : ' + $depsLine)
 Write-Host ('Build     : ' + $buildStatus)
 Write-Host ('Tests     : ' + $testsLine)
-Write-Host ('Log       : {0}  (sha256: {1})' -f $Log, $logHash)
+Write-Host ('Log sha256: ' + $logHash)
 Write-Host '================================'
 
 if ($buildStatus -ne 'Succeeded') { exit 1 }

--- a/Scripts/build_and_test.sh
+++ b/Scripts/build_and_test.sh
@@ -21,22 +21,26 @@
 # This plugin incorporates third-party software: MuJoCo (Apache 2.0),
 # CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
 
-# build_and_test.sh — build url_projEditor and run the URLab automation suite,
-# then print a machine-identifiable summary block to paste into a PR.
+# build_and_test.sh — build the project's Editor target and run the URLab
+# automation suite, then print a machine-identifiable summary block to paste
+# into a PR.
 #
 # Usage:
 #   ./Scripts/build_and_test.sh \
 #       --engine "/c/Program Files/Epic Games/UE_5.7" \
 #       --project "C:/path/to/your.uproject" \
-#       [--target url_projEditor] \
+#       [--target CustomEditorTargetName] \
 #       [--filter URLab] \
 #       [--log /tmp/urlab_test.log]
+#
+# --target defaults to <ProjectName>Editor derived from the .uproject filename.
+# Only override for projects that don't follow UE's naming convention.
 #
 # Exit codes: 0 ok, 1 build failed, 2 tests failed, 3 bad args.
 
 set -eu
 
-TARGET="url_projEditor"
+TARGET=""
 FILTER="URLab"
 LOG="/tmp/urlab_test.log"
 ENGINE=""
@@ -44,15 +48,17 @@ PROJECT=""
 
 usage() {
     cat >&2 <<'HELP'
-build_and_test.sh — build url_projEditor and run the URLab automation suite.
+build_and_test.sh — build the project's Editor target and run the URLab automation suite.
 
 Usage:
   ./Scripts/build_and_test.sh \
       --engine "/c/Program Files/Epic Games/UE_5.7" \
       --project "C:/path/to/your.uproject" \
-      [--target url_projEditor] \
+      [--target CustomEditorTargetName] \
       [--filter URLab] \
       [--log /tmp/urlab_test.log]
+
+--target defaults to <ProjectName>Editor derived from the .uproject filename.
 
 Exit codes: 0 ok, 1 build failed, 2 tests failed, 3 bad args.
 HELP
@@ -74,10 +80,18 @@ done
 [[ -z "$ENGINE"  ]] && { echo "Missing --engine"  >&2; usage; }
 [[ -z "$PROJECT" ]] && { echo "Missing --project" >&2; usage; }
 
-UBT="$ENGINE/Engine/Binaries/DotNET/UnrealBuildTool/UnrealBuildTool.exe"
+# Derive the editor target from the .uproject filename if not explicitly
+# supplied. UE's convention is <ProjectName>Editor — e.g. MyGame.uproject ->
+# MyGameEditor. Override with --target for projects that don't follow this.
+if [[ -z "$TARGET" ]]; then
+    PROJECT_BASENAME=$(basename "$PROJECT")
+    TARGET="${PROJECT_BASENAME%.*}Editor"
+fi
+
+BAT="$ENGINE/Engine/Build/BatchFiles/Build.bat"
 CMD="$ENGINE/Engine/Binaries/Win64/UnrealEditor-Cmd.exe"
 
-[[ -x "$UBT" ]] || { echo "UBT not found: $UBT" >&2; exit 3; }
+[[ -f "$BAT" ]] || { echo "Build.bat not found: $BAT" >&2; exit 3; }
 [[ -x "$CMD" ]] || { echo "UnrealEditor-Cmd not found: $CMD" >&2; exit 3; }
 
 # Truncate the test log up-front so a build failure (or any early exit
@@ -87,7 +101,10 @@ CMD="$ENGINE/Engine/Binaries/Win64/UnrealEditor-Cmd.exe"
 
 # --- Build -----------------------------------------------------------------
 echo ">>> Building $TARGET (Win64 Development)..."
-BUILD_OUT=$("$UBT" "$TARGET" Win64 Development "-Project=$PROJECT" -WaitMutex 2>&1 || true)
+# Note: -TargetType=Editor is intentionally omitted. Combined with a positional
+# target name it makes UBT's two action-graph passes ambiguous and bails with
+# Result: Failed (ActionGraphInvalid). Just the positional target is enough.
+BUILD_OUT=$("$BAT" "$TARGET" Win64 Development "-Project=$PROJECT" -Progress 2>&1 || true)
 echo "$BUILD_OUT" | tail -10
 if echo "$BUILD_OUT" | grep -q "Result: Succeeded"; then
     BUILD_STATUS="Succeeded"
@@ -120,10 +137,37 @@ if [[ "$BUILD_STATUS" == "Succeeded" ]]; then
 fi
 
 # --- Fingerprint + summary -------------------------------------------------
+# Note: Host and Log-path lines are intentionally omitted from the summary
+# block because they leak the reporter's hostname / username on local runs.
+# The SHA-256 of the log is sufficient for reviewers to verify content
+# integrity when they re-run the suite themselves (#37).
 TS=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
-HOST=$(hostname 2>/dev/null || echo "unknown")
 GIT_SHA=$(git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
 GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+
+# Strip the engine path down to its last segment (e.g. 'UE_5.7'). The full
+# path can contain the user's install root on a non-standard layout.
+ENGINE_LABEL=$(basename "$ENGINE")
+[[ -z "$ENGINE_LABEL" ]] && ENGINE_LABEL="$ENGINE"
+
+# Third-party dep SHAs from third_party/install/<dep>/INSTALLED_SHA.txt
+# (written by the CMake build scripts). Lets a reviewer verify they're
+# comparing against the same binary toolchain. Silent skip if missing.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PLUGIN_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+DEPS_LINE=""
+for pair in "mj:MuJoCo" "coacd:CoACD" "zmq:libzmq"; do
+    key="${pair%%:*}"
+    dir="${pair##*:}"
+    sha_file="$PLUGIN_ROOT/third_party/install/$dir/INSTALLED_SHA.txt"
+    if [[ -s "$sha_file" ]]; then
+        sha=$(head -c 7 "$sha_file")
+        if [[ -n "$DEPS_LINE" ]]; then DEPS_LINE="$DEPS_LINE "; fi
+        DEPS_LINE="${DEPS_LINE}${key}=${sha}"
+    fi
+done
+[[ -z "$DEPS_LINE" ]] && DEPS_LINE="unavailable"
+
 LOG_HASH="n/a"
 if [[ -s "$LOG" ]]; then
     if command -v sha256sum >/dev/null 2>&1; then
@@ -137,12 +181,12 @@ cat <<EOF
 
 === URLab build+test summary ===
 Timestamp : $TS
-Host      : $HOST
 Git HEAD  : $GIT_SHA ($GIT_BRANCH)
-Engine    : $ENGINE
+Engine    : $ENGINE_LABEL
+Deps      : $DEPS_LINE
 Build     : $BUILD_STATUS
 Tests     : $PASS / $TOTAL passed ($FAIL failed)${TESTS_PERFORMED_LINE:+  [$TESTS_PERFORMED_LINE]}
-Log       : $LOG  (sha256: $LOG_HASH)
+Log sha256: $LOG_HASH
 ================================
 EOF
 


### PR DESCRIPTION
## Summary

- Adopts @SiegeLordEx's Build.bat migration from #36 (kept as-is in \`0379d08\`) and layers the counter-proposal he agreed to on top: auto-derive \`<ProjectName>Editor\` from the \`.uproject\` filename, keep an override via \`-Target\` / \`--target\`, drop \`-TargetType=Editor\` (which was causing \`Result: Failed (ActionGraphInvalid)\` on my layout by making UBT's two action-graph passes ambiguous).
- Scrubs the summary block (#37): drops the \`Host\` line, drops the full \`Log : <path>\` line (kept only \`Log sha256:\` — which is the reviewer-verification signal), trims \`Engine\` to its basename (\`UE_5.7\`) so a non-standard install location doesn't leak an install-root path.
- Adds a \`Deps\` line to the summary: reads \`third_party/install/{MuJoCo,CoACD,libzmq}/INSTALLED_SHA.txt\` (the files landed in #39) and emits \`mj=72cb2b2 coacd=c7436bf zmq=7d95ac0\`. Reviewers can now verify three things at a glance — plugin commit, third-party commits, and test log hash — with no environment paths mixed in.
- Mirrors all three script changes in \`build_and_test.sh\`.
- Updates \`.github/pull_request_template.md\` example summary to match the new format.

## Motivation

Resolve username leaking and path issues in build and test script.

## Linked issue

Closes #37. Supersedes #36 — thanks @SiegeLordEx for the original.

## Build + test evidence


```
=== URLab build+test summary ===
Timestamp : 2026-04-22 20:21:48 UTC
Git HEAD  : 0379d08d (fix_test_script)
Engine    : UE_5.7
Deps      : mj=72cb2b2 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 177 / 177 passed (0 failed)  [177 tests performed]
Log sha256: dd9f91697afcc4c2
================================
```


## Manual verification steps

1. \`.\Scripts\build_and_test.ps1 -Engine '<UE-path>' -Project '<uproject-path>'\`
2. Confirm the summary block contains \`Engine : UE_X.Y\`, not a full path.
3. Confirm no \`Host :\` line and no \`Log : <path>\` line.
4. Confirm \`Deps :\` shows three 7-char SHAs if third-party installs exist, or \`unavailable\` if not.
5. For non-URLab projects: pass \`-Target MyCustomEditorTargetName\` to override the derived name.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full \`URLab.*\` automation suite passes (177/177)
- [x] Docs updated for user-facing changes (PR template example block matches new format)