### PR TITLE
Fix libzmq DLL preload to work with any MSVC toolset

### DIFF
--- a/Source/URLab/Private/URLab.cpp
+++ b/Source/URLab/Private/URLab.cpp
@@ -21,6 +21,7 @@
 // CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
 
 #include "URLab.h"
+#include "HAL/FileManager.h"
 #include "Misc/Paths.h"
 #include "Misc/MessageDialog.h"
 #include "Utils/URLabLogging.h"
@@ -37,47 +38,83 @@ void FURLabModule::StartupModule()
     FString PluginDir = IPluginManager::Get().FindPlugin("UnrealRoboticsLab")->GetBaseDir();
     FString InstallDir = FPaths::Combine(PluginDir, TEXT("third_party/install"));
 
-    // Function to load a shared library and log success/failure. BinSubDir is
-    // the per-package subdirectory under third_party/install/<SubDir>/ that
-    // holds the loadable artifact: "bin" on Windows (DLLs), "lib" on Linux
-    // (.so files).
-    auto LoadDependencyDLL = [&](const FString& LibraryName, const FString& SubDir, const FString& BinSubDir) {
-        // Try plugin third-party path first (editor / development)
-        FString DLLPath = FPaths::Combine(InstallDir, SubDir, BinSubDir, LibraryName);
-        if (!FPaths::FileExists(DLLPath))
-        {
-            // Packaged build: shared libs staged next to the executable
-            DLLPath = FPaths::Combine(FPlatformProcess::GetModulesDirectory(), LibraryName);
+    // Resolve LibraryPattern (literal filename or shell-style wildcard) to
+    // an absolute path inside SearchDir, or empty if no file matches.
+    auto ResolveLibraryFile = [](const FString& SearchDir, const FString& LibraryPattern) -> FString {
+        if (!LibraryPattern.Contains(TEXT("*"))) {
+            const FString Candidate = FPaths::Combine(SearchDir, LibraryPattern);
+            return FPaths::FileExists(Candidate) ? Candidate : FString();
         }
-        if (FPaths::FileExists(DLLPath)) {
-            void* Handle = FPlatformProcess::GetDllHandle(*DLLPath);
-            if (Handle) {
-                UE_LOG(LogURLab, Log, TEXT("Loaded %s from %s"), *LibraryName, *DLLPath);
-                return true;
-            } else {
-                UE_LOG(LogURLab, Error, TEXT("Failed to load %s from %s"), *LibraryName, *DLLPath);
-            }
-        } else {
-            UE_LOG(LogURLab, Error, TEXT("%s not found (searched plugin dir + binary dir)"), *LibraryName);
+        TArray<FString> Matches;
+        IFileManager::Get().FindFiles(Matches, *FPaths::Combine(SearchDir, LibraryPattern),
+                                      /*Files=*/true, /*Directories=*/false);
+        return Matches.Num() > 0 ? FPaths::Combine(SearchDir, Matches[0]) : FString();
+    };
+
+    // Load a shared library and log success/failure. LibraryPattern may
+    // contain `*` so we can match toolset-versioned filenames (libzmq bakes
+    // the MSVC toolset version into its DLL name; building with a different
+    // toolset than the URLab hardcode used to surface as a delay-load
+    // 0xc06d007e on first ZMQ call). BinSubDir is the per-package
+    // subdirectory under third_party/install/<SubDir>/ that holds the
+    // loadable artifact: "bin" on Windows (DLLs), "lib" on Linux (.so).
+    auto LoadDependencyDLL = [&](const FString& LibraryPattern, const FString& SubDir, const FString& BinSubDir) {
+        // Try plugin third-party path first (editor / development).
+        FString DLLPath = ResolveLibraryFile(FPaths::Combine(InstallDir, SubDir, BinSubDir), LibraryPattern);
+        if (DLLPath.IsEmpty()) {
+            // Packaged build: shared libs staged next to the executable.
+            DLLPath = ResolveLibraryFile(FPlatformProcess::GetModulesDirectory(), LibraryPattern);
         }
+        if (DLLPath.IsEmpty()) {
+            UE_LOG(LogURLab, Error,
+                TEXT("%s not found in third_party/install/%s/%s or the modules directory. "
+                     "Run third_party/build_all.ps1 (Windows) or build_all.sh (Linux/macOS) "
+                     "from the plugin root, then rebuild the editor."),
+                *LibraryPattern, *SubDir, *BinSubDir);
+            return false;
+        }
+        void* Handle = FPlatformProcess::GetDllHandle(*DLLPath);
+        if (Handle) {
+            UE_LOG(LogURLab, Log, TEXT("Loaded %s from %s"), *FPaths::GetCleanFilename(DLLPath), *DLLPath);
+            return true;
+        }
+        UE_LOG(LogURLab, Error, TEXT("Failed to load %s (GetLastError surfaces in delay-load fault otherwise)"), *DLLPath);
         return false;
     };
 
+    bool bAllDepsLoaded = true;
 #if PLATFORM_WINDOWS
     // Load MuJoCo. Since 3.7.0 the obj/stl decoders are compiled into
     // mujoco.dll itself (changelog item 9); loading the standalone
     // obj_decoder.dll / stl_decoder.dll would cause a plugin-registration
     // collision and crash during module init.
-    LoadDependencyDLL(TEXT("mujoco.dll"), TEXT("MuJoCo"), TEXT("bin"));
-    LoadDependencyDLL(TEXT("libzmq-v143-mt-4_3_6.dll"), TEXT("libzmq"), TEXT("bin"));
-    LoadDependencyDLL(TEXT("lib_coacd.dll"), TEXT("CoACD"), TEXT("bin"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("mujoco.dll"), TEXT("MuJoCo"), TEXT("bin"));
+    // libzmq's CMake bakes <toolset>-<threading>-<abi> into the output
+    // name (e.g. libzmq-v143-mt-4_3_6.dll for VS 2022, libzmq-v144-*
+    // for newer toolsets). Glob so URLab works regardless of which VS
+    // version the user built third_party with.
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libzmq-*-mt-*.dll"), TEXT("libzmq"), TEXT("bin"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("lib_coacd.dll"), TEXT("CoACD"), TEXT("bin"));
 #elif PLATFORM_LINUX
     // Linux .so layout: third_party/install/<pkg>/lib/. Names are SONAMEs
     // produced by the upstream cmake builds.
-    LoadDependencyDLL(TEXT("libmujoco.so.3.7.0"), TEXT("MuJoCo"), TEXT("lib"));
-    LoadDependencyDLL(TEXT("libzmq.so.5"), TEXT("libzmq"), TEXT("lib"));
-    LoadDependencyDLL(TEXT("lib_coacd.so"), TEXT("CoACD"), TEXT("lib"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libmujoco.so.3.7.0"), TEXT("MuJoCo"), TEXT("lib"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libzmq.so.5"), TEXT("libzmq"), TEXT("lib"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("lib_coacd.so"), TEXT("CoACD"), TEXT("lib"));
 #endif
+
+    if (!bAllDepsLoaded) {
+        // Surface the failure now instead of letting the first ZMQ / MuJoCo
+        // call fault with delay-load's generic 0xc06d007e.
+        const FText Title = LOCTEXT("URLabDllLoadFailedTitle", "URLab: third-party DLL load failed");
+        const FText Body = LOCTEXT("URLabDllLoadFailedBody",
+            "URLab could not load one or more required third-party libraries "
+            "(MuJoCo / libzmq / CoACD).\n\n"
+            "Run third_party/build_all.ps1 (Windows) or build_all.sh (Linux/macOS) "
+            "from the plugin root, then rebuild the editor.\n\n"
+            "See the URLab log for the missing file name(s).");
+        FMessageDialog::Open(EAppMsgType::Ok, Body, Title);
+    }
 
     // Some CoACD dependencies like TBB or runtimes might be in CoACD/bin
     // They should be loaded automatically if in search path, but we can verify here if needed.


### PR DESCRIPTION
## Summary

* Resolve libzmq DLL by glob (`libzmq-*-mt-*.dll`) so any MSVC toolset works.
* Show a message dialog if any third_party DLL fails to preload, instead of a generic 0xc06d007e on first call.

## Motivation

libzmq's CMake bakes the MSVC toolset version into the output filename (`libzmq-v143-mt-4_3_6.dll` for VS 2022). `URLab.cpp` hardcoded the `v143` literal, so building third_party with a different toolset (issue reporter used VS 2026) made the preload silently fail. The first ZMQ call then surfaced delay load's `0xc06d007e` with no actionable info.

## Linked issue

Fixes #49

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-05-11T18:23:14Z
Git HEAD  : 2c940ec (fix/libzmq_dll_name_glob)
Engine    : UE_5.7
Deps      : mj=72cb2b2 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 177 / 177 passed (0 failed)
Log sha256: 5d852ebf9d8d72187cfd604275bfca1e3f75c354dbf8b13dbc5e38f807b1a8e8
================================
```

## Manual verification steps

Open any URLab scene in PIE. Editor starts normally, no dialog. To exercise the new glob path, rename `third_party/install/libzmq/bin/libzmq-v143-mt-4_3_6.dll` to a `v144` prefix; with this fix the preload still resolves it. Before the fix the same rename produced `0xc06d007e` on first ZMQ call.

## Checklist

* [x] Builds locally against UE 5.7+
* [x] Full `URLab.*` automation suite passes
* [x] Docs updated for user facing changes (no doc change needed)