### PR TITLE
chore(scripts): Apache header on diff_schema; clean_meshes deps note

### DIFF
--- a/Scripts/clean_meshes.py
+++ b/Scripts/clean_meshes.py
@@ -28,7 +28,7 @@ resolves naming conflicts (e.g., link1.obj and link1.stl both becoming link1.glb
 and writes an updated XML ready for drag-and-drop import into Unreal.
 
 Installation:
-    pip install trimesh numpy
+    pip install trimesh numpy scipy Pillow
 
 Usage:
     python clean_meshes_trimesh.py <path_to_xml>

--- a/Scripts/diff_schema.py
+++ b/Scripts/diff_schema.py
@@ -1,3 +1,25 @@
+# Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# --- LEGAL DISCLAIMER ---
+# UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+# endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+# trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+#
+# This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+# CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
 """
 Diff two MJCF schema snapshots to find new/removed elements and attributes.
 


### PR DESCRIPTION
Two small drive-by tidies under `Scripts/`:

- `diff_schema.py` gains the standard Apache 2.0 + URLab legal header (was missing).
- `clean_meshes.py` docstring lists `scipy` and `Pillow` in the pip install line since trimesh pulls them in when those features are exercised.