### PR TITLE
fix: misc import + build correctness

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
@@ -161,7 +161,6 @@ void UMjGeom::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& Com
     }
     MeshName = mesh;
 
-    // Mark this geom as having been produced by XML import.
     bWasImported = true;
 }
 

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjBox.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjBox.cpp
@@ -113,10 +113,10 @@ void UMjBox::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& Comp
 
 void UMjBox::ExportTo(mjsGeom* Element, mjsDefault* def)
 {
-    // For user-authored boxes, derive size from the Unreal scale.
-    // Unreal Cube is 100 units; MuJoCo box size is half-extents in metres.
-    // 1.0 Unreal scale -> 50cm half-extent -> 0.5 size.
-    if (!bWasImported)
+    // See UMjSphere::ExportTo for the guard rationale: derive from scale
+    // when user-authored or when imported with an explicit size attr; skip
+    // when imported with inherited size so MuJoCo's class default applies.
+    if (!bWasImported || bOverride_size)
     {
         const FVector scale = GetRelativeScale3D();
         size = { (float)scale.X * 0.5f, (float)scale.Y * 0.5f, (float)scale.Z * 0.5f };

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjCapsule.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjCapsule.cpp
@@ -163,10 +163,8 @@ void UMjCapsule::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& 
 
 void UMjCapsule::ExportTo(mjsGeom* Element, mjsDefault* def)
 {
-    // For user-authored capsules, derive (radius, half-length) from the
-    // Unreal scale. Base cylinder is 100cm diameter (radius 50cm) → scale
-    // 1.0 = 50cm radius = 0.5 m.
-    if (!bWasImported)
+    // See UMjSphere::ExportTo for the guard rationale.
+    if (!bWasImported || bOverride_size)
     {
         const FVector scale = GetRelativeScale3D();
         size = { (float)scale.X * 0.5f, (float)scale.Z * 0.5f };

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjCylinder.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjCylinder.cpp
@@ -102,10 +102,8 @@ void UMjCylinder::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings&
 
 void UMjCylinder::ExportTo(mjsGeom* Element, mjsDefault* def)
 {
-    // For user-authored cylinders, derive (radius, half-length) from the
-    // Unreal scale. Unreal Cylinder: diameter=100, Height=100. MuJoCo
-    // cylinder size: [radius, half-length] in metres.
-    if (!bWasImported)
+    // See UMjSphere::ExportTo for the guard rationale.
+    if (!bWasImported || bOverride_size)
     {
         const FVector scale = GetRelativeScale3D();
         size = { (float)scale.X * 0.5f, (float)scale.Z * 0.5f };

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjSphere.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/Primitives/MjSphere.cpp
@@ -93,10 +93,13 @@ void UMjSphere::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& C
 
 void UMjSphere::ExportTo(mjsGeom* Element, mjsDefault* def)
 {
-    // For user-authored spheres, derive radius from the Unreal scale.
-    // Unreal Sphere is 100 units diameter; MuJoCo sphere size is radius in metres.
-    // 1.0 Unreal scale -> 50cm radius -> 0.5 size.
-    if (!bWasImported)
+    // Derive size from RelativeScale3D when (a) user-authored, or
+    // (b) imported with an explicit size attr. The second condition lets
+    // a user rescale an imported sphere in the viewport and have the
+    // change reach the physics geom. Imported-with-inherited-size geoms
+    // (bOverride_size=false) skip this so MuJoCo's class-default
+    // inheritance still applies on compile.
+    if (!bWasImported || bOverride_size)
     {
         const FVector scale = GetRelativeScale3D();
         size = { (float)scale.X * 0.5f };

--- a/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
@@ -25,8 +25,8 @@
 #include "MuJoCo/Core/MjPhysicsEngine.h"
 #include "MuJoCo/Core/MjDebugVisualizer.h"
 #include "MuJoCo/Net/MjNetworkManager.h"
-#include "MuJoCo/input/MjInputHandler.h"
-#include "MuJoCo/input/MjPerturbation.h"
+#include "MuJoCo/Input/MjInputHandler.h"
+#include "MuJoCo/Input/MjPerturbation.h"
 #include "Replay/MjReplayManager.h"
 #include "mujoco/mujoco.h"
 

--- a/Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjInputHandler.cpp
@@ -20,11 +20,11 @@
 // This plugin incorporates third-party software: MuJoCo (Apache 2.0),
 // CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
 
-#include "MuJoCo/input/MjInputHandler.h"
+#include "MuJoCo/Input/MjInputHandler.h"
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Core/MjDebugVisualizer.h"
 #include "MuJoCo/Core/MjPhysicsEngine.h"
-#include "MuJoCo/input/MjPerturbation.h"
+#include "MuJoCo/Input/MjPerturbation.h"
 #include "Framework/Application/IInputProcessor.h"
 #include "Framework/Application/SlateApplication.h"
 #include "InputCoreTypes.h"

--- a/Source/URLab/Private/MuJoCo/Input/MjPerturbation.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjPerturbation.cpp
@@ -20,7 +20,7 @@
 // This plugin incorporates third-party software: MuJoCo (Apache 2.0),
 // CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
 
-#include "MuJoCo/input/MjPerturbation.h"
+#include "MuJoCo/Input/MjPerturbation.h"
 
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Core/MjPhysicsEngine.h"

--- a/Source/URLab/Private/MuJoCo/Input/MjTwistController.cpp
+++ b/Source/URLab/Private/MuJoCo/Input/MjTwistController.cpp
@@ -20,7 +20,7 @@
 // This plugin incorporates third-party software: MuJoCo (Apache 2.0),
 // CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
 
-#include "MuJoCo/input/MjTwistController.h"
+#include "MuJoCo/Input/MjTwistController.h"
 #include "EnhancedInputComponent.h"
 #include "InputAction.h"
 

--- a/Source/URLab/Private/MuJoCo/Net/ZmqSensorBroadcaster.cpp
+++ b/Source/URLab/Private/MuJoCo/Net/ZmqSensorBroadcaster.cpp
@@ -25,7 +25,7 @@
 #include "MuJoCo/Core/MjArticulation.h"
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Components/MjComponent.h"
-#include "MuJoCo/input/MjTwistController.h"
+#include "MuJoCo/Input/MjTwistController.h"
 #include "Serialization/BufferArchive.h"
 #include "Utils/URLabLogging.h"
 

--- a/Source/URLab/Private/UI/MjSimulateWidget.cpp
+++ b/Source/URLab/Private/UI/MjSimulateWidget.cpp
@@ -39,7 +39,7 @@
 #include "Components/SizeBox.h"
 #include "Components/Spacer.h"
 #include "MuJoCo/Core/MjArticulation.h"
-#include "MuJoCo/input/MjTwistController.h"
+#include "MuJoCo/Input/MjTwistController.h"
 #include "Styling/SlateTypes.h"
 #include "Fonts/SlateFontInfo.h"
 #include "MuJoCo/Utils/MjUtils.h"

--- a/Source/URLab/Private/URLab.cpp
+++ b/Source/URLab/Private/URLab.cpp
@@ -96,11 +96,12 @@ void FURLabModule::StartupModule()
     bAllDepsLoaded &= LoadDependencyDLL(TEXT("libzmq-*-mt-*.dll"), TEXT("libzmq"), TEXT("bin"));
     bAllDepsLoaded &= LoadDependencyDLL(TEXT("lib_coacd.dll"), TEXT("CoACD"), TEXT("bin"));
 #elif PLATFORM_LINUX
-    // Linux .so layout: third_party/install/<pkg>/lib/. Names are SONAMEs
-    // produced by the upstream cmake builds.
-    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libmujoco.so.3.7.0"), TEXT("MuJoCo"), TEXT("lib"));
-    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libzmq.so.5"), TEXT("libzmq"), TEXT("lib"));
-    bAllDepsLoaded &= LoadDependencyDLL(TEXT("lib_coacd.so"), TEXT("CoACD"), TEXT("lib"));
+    // Linux .so layout: third_party/install/<pkg>/lib/. Glob the SONAME
+    // suffix so a MuJoCo bump (or any minor version bump) doesn't require
+    // tracking the literal version in the loader.
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libmujoco.so*"), TEXT("MuJoCo"), TEXT("lib"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("libzmq.so*"), TEXT("libzmq"), TEXT("lib"));
+    bAllDepsLoaded &= LoadDependencyDLL(TEXT("lib_coacd.so*"), TEXT("CoACD"), TEXT("lib"));
 #endif
 
     if (!bAllDepsLoaded) {

--- a/Source/URLab/Public/MuJoCo/Components/Geometry/MjGeom.h
+++ b/Source/URLab/Public/MuJoCo/Components/Geometry/MjGeom.h
@@ -323,25 +323,13 @@ public:
 	 * fromto canonicalisation writes into size[1]/[2] depending on shape.
 	 */
 
-    /**
-     * @brief True when this component was created via ImportFromXml (i.e. loaded from a .xml file).
-     * False for components that are manually authored by the user in the editor.
-     * Used by ShouldOverrideSize() to distinguish "inherit-from-default" intent
-     * (imported, bOverride_size=false) from "use my UE scale" intent (user-authored).
-     */
+    /** True when this component was created via ImportFromXml. Lets export
+     *  preserve "size inherited from default class" semantics: for an
+     *  imported geom with no explicit size attr (bOverride_size=false) we
+     *  must NOT derive size from RelativeScale3D on export, otherwise
+     *  MuJoCo's default-class inheritance won't fire. */
     UPROPERTY()
     bool bWasImported = false;
-
-    /**
-     * @brief Returns true if the geom's size should be written to MuJoCo on export
-     * and the UE scale should NOT be overwritten from the MuJoCo default on Bind.
-     *
-     * Semantics:
-     *  - Imported geom, explicit size in XML  (bWasImported=true,  bOverride_size=true)  -> true
-     *  - Imported geom, no size in XML        (bWasImported=true,  bOverride_size=false) -> false (inherit default)
-     *  - User-authored geom                   (bWasImported=false, bOverride_size=any)   -> true (use UE scale)
-     */
-    bool ShouldOverrideSize() const { return bOverride_size || !bWasImported; }
 
     /** @brief Name of the mesh asset if Type is mesh. */
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "MuJoCo|Geom")

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -333,6 +333,44 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
             TypeStr = TEXT("mesh");
         }
 
+        // Resolve type inherited from a class default. MJCF allows
+        // <default class="foo"><geom type="box"/></default>
+        // then bare <geom class="foo"/> or <geom/> inside a body with
+        // childclass="foo". Without this, the parser picked the URLab
+        // base UMjGeom (no primitive subclass) and the wrong renderer.
+        if (TypeStr.IsEmpty())
+        {
+            FString SearchClass = Node->GetAttribute(TEXT("class"));
+            if (SearchClass.IsEmpty() && ParentNode)
+            {
+                if (UMjBody* ParentBody = Cast<UMjBody>(ParentNode->ComponentTemplate))
+                {
+                    SearchClass = ParentBody->childclass;
+                }
+            }
+            if (!SearchClass.IsEmpty() && CreatedDefaultNodes.Contains(SearchClass))
+            {
+                if (USCS_Node* DefNode = CreatedDefaultNodes[SearchClass])
+                {
+                    for (USCS_Node* DefChild : DefNode->ChildNodes)
+                    {
+                        UMjGeom* DefGeom = Cast<UMjGeom>(DefChild->ComponentTemplate);
+                        if (!DefGeom) continue;
+                        switch (DefGeom->Type)
+                        {
+                            case EMjGeomType::Box:      TypeStr = TEXT("box"); break;
+                            case EMjGeomType::Sphere:   TypeStr = TEXT("sphere"); break;
+                            case EMjGeomType::Capsule:  TypeStr = TEXT("capsule"); break;
+                            case EMjGeomType::Cylinder: TypeStr = TEXT("cylinder"); break;
+                            case EMjGeomType::Plane:    TypeStr = TEXT("plane"); break;
+                            default: break;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         if (Name.IsEmpty())
         {
             FString GeomTypeName = TypeStr.IsEmpty() ? TEXT("Sphere") : TypeStr;


### PR DESCRIPTION
Four small fixes uncovered by recent testing.

## Commits

- \`fix(linux)\` — DLL loader hardcoded \`libmujoco.so.3.7.0\` / \`libzmq.so.5\` / \`lib_coacd.so\`, which stopped matching after the MuJoCo bump. Glob the SONAME suffix.
- \`fix(includes)\` — six files referenced \`MuJoCo/input/\` (lowercase). NTFS doesn't care; ext4 does. The directory is \`MuJoCo/Input/\`.
- \`fix(import)\` — bare \`<geom class=\"foo\"/>\` inside a body that inherits from a default fell back to the base \`UMjGeom\` (no primitive subclass) because the parser only looked at the geom's own \`type\` attr. Walk one level of class / childclass default to resolve the type, then pick the matching UMjBox / Sphere / Capsule / Cylinder / Plane subclass.
- \`fix(geom)\` — imported primitive geoms now respect user-driven \`RelativeScale3D\` changes on export. Previously a user rescaling an imported sphere in the viewport saw the visual change but the simulated size stayed pinned to the import value. Guard switches from \`!bWasImported\` to \`!bWasImported \|\| bOverride_size\`, so import-with-explicit-size geoms also derive from scale on export. Imported geoms with size inherited from a class default still skip the derive so MuJoCo's class-default inheritance applies at compile time.

## Build + test

\`\`\`
=== URLab build+test summary ===
Timestamp : 2026-05-27 18:23:20 UTC
Git HEAD  : 396552ae (chore/import-and-build-fixes)
Engine    : UE_5.7
Deps      : mj=6882095 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 206 / 206 passed (0 failed)  [206 tests performed]
Log sha256: 93d4b7d01bbd2c98
================================
\`\`\`

## Test plan

- [x] URLab automation suite passes (206 / 206).
- [ ] Linux build picks up the SOs without manual symlinks.
- [ ] Manual: drag-resize an imported primitive sphere/box in the UE viewport; restart PIE; confirm the simulated geom size matches the new scale.