### PR TITLE
fix(components): add missing MjXmlUtils.h includes (fixes Linux build)

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Actuators/MjGeneralActuator.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Actuators/MjGeneralActuator.cpp
@@ -22,6 +22,7 @@
 
 #include "MuJoCo/Components/Actuators/MjGeneralActuator.h"
 #include "MuJoCo/Utils/MjOrientationUtils.h"
+#include "MuJoCo/Utils/MjXmlUtils.h"
 
 UMjGeneralActuator::UMjGeneralActuator()
 {

--- a/Source/URLab/Private/MuJoCo/Components/Physics/MjContactExclude.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Physics/MjContactExclude.cpp
@@ -28,6 +28,7 @@
 #include "MuJoCo/Components/Bodies/MjBody.h"
 #include "Utils/URLabLogging.h"
 #include "MuJoCo/Utils/MjOrientationUtils.h"
+#include "MuJoCo/Utils/MjXmlUtils.h"
 
 UMjContactExclude::UMjContactExclude()
 {


### PR DESCRIPTION
## Summary

- `MjGeneralActuator.cpp` and `MjContactExclude.cpp` use `MjXmlUtils::ReadAttr*` but neither file includes `MuJoCo/Utils/MjXmlUtils.h`.
- Windows builds because UE unity-build concatenates several .cpp into one TU and the include leaks in from a neighbour.
- Linux clang surfaces the bug as `use of undeclared identifier 'MjXmlUtils'; did you mean 'MjUtils'?` during compile.

## Motivation

Reported by a contributor following the Linux setup guide. Fix lets the URLab plugin compile on Ubuntu 22.04 against UE 5.7's precompiled binaries.

## Linked issue

None.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-06-10 06:52:30 UTC
Git HEAD  : b4000e58 (fix/missing-mjxmlutils-include)
Engine    : UE_5.7
Deps      : mj=6882095 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 206 / 206 passed (0 failed)  [206 tests performed]
Log sha256: d2d20f701635db7c
```

## Manual verification steps

- On Linux: `Build.sh url_projEditor Linux Development` compiles `MjGeneralActuator.cpp` and `MjContactExclude.cpp` without the `MjXmlUtils` undeclared-identifier error.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full URLab.* automation suite passes (206/206)
- [x] Docs updated for user-facing changes (no docs change required)