### PR TITLE
fix(import): mesh / material / camera intrinsic touch-ups

### DIFF
--- a/Scripts/clean_meshes.py
+++ b/Scripts/clean_meshes.py
@@ -28,7 +28,7 @@ resolves naming conflicts (e.g., link1.obj and link1.stl both becoming link1.glb
 and writes an updated XML ready for drag-and-drop import into Unreal.
 
 Installation:
-    pip install trimesh numpy scipy Pillow
+    pip install trimesh numpy scipy Pillow networkx
 
 Usage:
     python clean_meshes_trimesh.py <path_to_xml>
@@ -51,7 +51,11 @@ def clean_mesh(mesh):
 
     mesh.merge_vertices(merge_tex=False, merge_norm=False)
     mesh.remove_unreferenced_vertices()
-    mesh.fix_normals()
+    try:
+        import networkx  # noqa: F401 - trimesh's fix_normals requires it
+        mesh.fix_normals()
+    except ImportError:
+        print("  Warning: networkx not installed, skipping fix_normals (GLB may have lighting issues)")
 
     # Rotate -90 degrees around X for GLTF Y-up -> Unreal Z-up
     rotation_matrix = trimesh.transformations.rotation_matrix(-np.radians(90), [1, 0, 0])

--- a/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Sensors/MjCamera.cpp
@@ -374,13 +374,16 @@ void UMjCamera::SetupRenderTarget()
     CaptureComponent->TextureTarget = RT;
     CaptureComponent->bAlwaysPersistRenderingState = true;
     CaptureComponent->MaxViewDistanceOverride = -1.0f;
+    // 1mm near clip on every capture mode — without this, robot-internal
+    // geometry can intrude on the frustum and produce black-on-black frames
+    // when the camera is mounted inside a body shell.
+    CaptureComponent->bOverride_CustomNearClippingPlane = true;
+    CaptureComponent->CustomNearClippingPlane = 0.1f;
 
     switch (CaptureMode)
     {
     case EMjCameraMode::Depth:
         CaptureComponent->CaptureSource = ESceneCaptureSource::SCS_SceneDepth;
-        CaptureComponent->bOverride_CustomNearClippingPlane = true;
-        CaptureComponent->CustomNearClippingPlane           = DepthNearCm;
         break;
 
     case EMjCameraMode::SemanticSegmentation:
@@ -756,15 +759,30 @@ void UMjCamera::ImportFromXml(const FXmlNode* Node, const FMjCompilerSettings& C
     if (!MjXmlUtils::ReadAttrString(Node, TEXT("name"), MjName))
         MjName = TEXT("Camera");
 
-    // fovy
+    // fovy — direct attribute wins; otherwise derive from MJCF intrinsics.
+    // MuJoCo's compiler computes fovy from focal_pixel / focal_length when
+    // present, so we mirror that here so the imported UE FOV matches what
+    // mujoco itself would report.
     FString FovyStr = Node->GetAttribute(TEXT("fovy"));
     if (!FovyStr.IsEmpty())
     {
         fovy = FCString::Atof(*FovyStr);
-        if (CaptureComponent)
-        {
-            CaptureComponent->FOVAngle = fovy;
-        }
+    }
+    else if (bOverride_focalpixel && focalpixel.Num() >= 2 && resolution.Num() >= 2 && focalpixel[1] > 0)
+    {
+        fovy = 2.0f * FMath::Atan2(static_cast<float>(resolution[1]), 2.0f * static_cast<float>(focalpixel[1])) * (180.0f / PI);
+    }
+    else if (bOverride_focal && focal.Num() >= 2 && sensorsize.Num() >= 2 && focal[1] > 0.0f)
+    {
+        fovy = 2.0f * FMath::Atan2(static_cast<float>(sensorsize[1]), 2.0f * static_cast<float>(focal[1])) * (180.0f / PI);
+    }
+    else if (fovy <= 0.0f)
+    {
+        fovy = 45.0f;
     }
 
+    if (CaptureComponent)
+    {
+        CaptureComponent->FOVAngle = fovy;
+    }
 }

--- a/Source/URLabEditor/Private/MujocoMeshImporter.cpp
+++ b/Source/URLabEditor/Private/MujocoMeshImporter.cpp
@@ -454,8 +454,11 @@ UMaterialInstanceConstant* UMujocoGenerationAction::CreateMaterialInstance(
         return nullptr;
     }
 
-    // Create material instance package
+    // Create material instance package. Strip path separators from the
+    // instance name — Unreal FNames don't tolerate '/', which corrupts the
+    // asset path for namespaced MJCF materials (e.g. "obstacles/box1").
     FString InstanceName = FString::Printf(TEXT("MI_%s"), *MeshName);
+    InstanceName = InstanceName.Replace(TEXT("/"), TEXT("_"));
     FString PackageName = FPaths::Combine(DestinationPath, InstanceName);
     PackageName = UPackageTools::SanitizePackageName(PackageName);
 

--- a/Source/URLabEditor/Private/MujocoXmlParser.cpp
+++ b/Source/URLabEditor/Private/MujocoXmlParser.cpp
@@ -198,6 +198,83 @@ static FString ResolveMaterialFromDefaults(const UMjGeom* GeomComp, UBlueprint* 
     return FString();
 }
 
+/**
+ * Resolves a geom's rgba colour through the default class chain, mirroring
+ * ResolveMaterialFromDefaults. The geom's own UPROPERTY default
+ * (FLinearColor::White) is meaningless during import — if the geom didn't
+ * explicitly set rgba, the colour should come from <default><geom rgba="..."/>
+ * up the class chain. Returns false when no default chain entry sets rgba,
+ * so the caller can fall back to the geom's own value.
+ */
+static bool ResolveGeomRgbaFromDefaults(const UMjGeom* GeomComp, UBlueprint* BP, FLinearColor& OutRgba)
+{
+    if (!GeomComp || !BP || !BP->SimpleConstructionScript) return false;
+
+    if (GeomComp->bOverride_rgba)
+    {
+        OutRgba = GeomComp->rgba;
+        return true;
+    }
+
+    FString ClassName = GeomComp->MjClassName;
+    TArray<USCS_Node*> AllNodes = BP->SimpleConstructionScript->GetAllNodes();
+
+    if (ClassName.IsEmpty())
+    {
+        for (USCS_Node* Node : AllNodes)
+        {
+            if (Node->ComponentTemplate == GeomComp)
+            {
+                for (USCS_Node* Parent : AllNodes)
+                {
+                    if (Parent->ChildNodes.Contains(Node))
+                    {
+                        if (UMjBody* Body = Cast<UMjBody>(Parent->ComponentTemplate))
+                        {
+                            if (Body->bOverride_childclass && !Body->childclass.IsEmpty())
+                            {
+                                ClassName = Body->childclass;
+                            }
+                        }
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    if (ClassName.IsEmpty()) return false;
+
+    TSet<FString> Visited;
+    while (!ClassName.IsEmpty() && !Visited.Contains(ClassName))
+    {
+        Visited.Add(ClassName);
+        for (USCS_Node* Node : AllNodes)
+        {
+            UMjDefault* Def = Cast<UMjDefault>(Node->ComponentTemplate);
+            if (!Def || Def->ClassName != ClassName) continue;
+
+            for (USCS_Node* ChildNode : Node->ChildNodes)
+            {
+                if (UMjGeom* ChildGeom = Cast<UMjGeom>(ChildNode->ComponentTemplate))
+                {
+                    if (ChildGeom->bOverride_rgba)
+                    {
+                        OutRgba = ChildGeom->rgba;
+                        return true;
+                    }
+                }
+            }
+
+            ClassName = Def->ParentClassName;
+            break;
+        }
+    }
+
+    return false;
+}
+
 void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Node* ParentNode, UBlueprint* BP,
                                           const FString& XMLDir, const FString& AssetImportPath,
                                           const TMap<FString, FString>& MeshAssets,
@@ -541,7 +618,10 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
 
                                  // Create and assign material instance
                                  FMuJoCoMaterialData MatData;
-                                 MatData.Rgba = GeomComp->rgba; // Use geom color as default
+                                 FLinearColor ResolvedRgba;
+                                 MatData.Rgba = ResolveGeomRgbaFromDefaults(GeomComp, BP, ResolvedRgba)
+                                                  ? ResolvedRgba
+                                                  : GeomComp->rgba;
 
                                  // Key by material name (resolved through default chain) if referenced, else fall back to mesh name
                                  FString ResolvedMat = ResolveMaterialFromDefaults(GeomComp, BP);
@@ -582,7 +662,10 @@ void UMujocoGenerationAction::ImportNodeRecursive(const FXmlNode* Node, USCS_Nod
 
                  // Create and assign material instance
                  FMuJoCoMaterialData MatData;
-                 MatData.Rgba = GeomComp->rgba; // Use geom color as default
+                 FLinearColor ResolvedRgba;
+                 MatData.Rgba = ResolveGeomRgbaFromDefaults(GeomComp, BP, ResolvedRgba)
+                                  ? ResolvedRgba
+                                  : GeomComp->rgba;
 
                  // Key by material name (resolved through default chain) if referenced, else fall back to geom name
                  FString ResolvedMat = ResolveMaterialFromDefaults(GeomComp, BP);

--- a/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjCameraTests.cpp
@@ -112,8 +112,12 @@ bool FMjCameraDepthModeConfig::RunTest(const FString& Parameters)
             (int32)Cam->CaptureComponent->CaptureSource,
             (int32)ESceneCaptureSource::SCS_SceneDepth);
         TestTrue(TEXT("near clip overridden"), Cam->CaptureComponent->bOverride_CustomNearClippingPlane);
+        // Frustum near clip is fixed at 0.1 cm for every capture mode to
+        // stop internal robot geometry from intruding on the view. The
+        // DepthNearCm property now controls only the post-process depth
+        // normalisation (see MjCameraFeedEntry.cpp).
         TestEqual(TEXT("near clip value"),
-            Cam->CaptureComponent->CustomNearClippingPlane, Cam->DepthNearCm);
+            Cam->CaptureComponent->CustomNearClippingPlane, 0.1f);
     }
 
     S.Cleanup();


### PR DESCRIPTION
## Summary

- `clean_meshes.py`: guard `trimesh.fix_normals` behind a `networkx` import and add it to the documented install line so the script no longer aborts mid-conversion.
- `MujocoMeshImporter`: replace `/` with `_` in generated material-instance names so namespaced MJCF materials (e.g. `obstacles/box1`) no longer corrupt the asset package path.
- `MjCamera::ImportFromXml`: derive `fovy` from `focal_pixel` / `focal_length` + `sensorsize` when the MJCF doesn't set fovy directly, matching MuJoCo's own compiler. Move the 0.1 cm near clip override out of the Depth-only branch so internal robot geometry doesn't clip Real / Segmentation captures.
- `MujocoXmlParser`: walk the default class chain looking for `bOverride_rgba` (parallel to the existing `ResolveMaterialFromDefaults`) so geoms picking up colour from `<default><geom rgba="..."/></default>` no longer render white.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-06-13 19:05:52 UTC
Git HEAD  : 768bd1d2 (fix/import-touch-ups)
Engine    : UE_5.7
Deps      : mj=6882095 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 206 / 206 passed (0 failed)  [206 tests performed]
Log sha256: b8b11a23d0288870
================================
```

## Manual verification steps

- Drag in any MJCF scene that references a `<default>` with `rgba` on a geom (Menagerie scenes are a good source) and confirm the imported visuals come in coloured rather than white.
- Drag in a scene with a camera declared via `focal` + `sensorsize` (e.g. realsense.xml) and confirm the SceneCapture2D FOVAngle on the imported camera matches MuJoCo's reported `fovy`.
- Drag in a scene with material names containing `/` and confirm no asset-path errors in the output log; the resulting `MI_*` assets land at the expected destination path.
- Run `python Scripts/clean_meshes.py path/to/scene.xml` in an env without `networkx` and confirm it warns once and continues, producing usable GLBs.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes
- [ ] Docs updated for user-facing changes