### PR TITLE
feat(physics): coherent per-step render snapshot for game-thread reads + UE-to-MuJoCo command queue

### DIFF
--- a/Source/URLab/Private/MuJoCo/Components/Bodies/MjBody.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Bodies/MjBody.cpp
@@ -27,6 +27,8 @@
 #include "MuJoCo/Components/Physics/MjInertial.h"
 #include "MuJoCo/Components/Geometry/MjSite.h"
 #include "MuJoCo/Components/Joints/MjJoint.h"
+#include "MuJoCo/Core/AMjManager.h"
+#include "MuJoCo/Core/MjPhysicsEngine.h"
 #include "MuJoCo/Core/Spec/MjSpecWrapper.h"
 #include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Utils/MjXmlUtils.h"
@@ -34,6 +36,29 @@
 #include "MuJoCo/Utils/MjOrientationUtils.h"
 #include "XmlNode.h"
 #include "PhysicsEngine/BodySetup.h"
+#include "EngineUtils.h"
+
+namespace
+{
+    UMjPhysicsEngine* GetEngine(const UObject* WorldCtx)
+    {
+        if (AAMjManager* Manager = AAMjManager::GetManager())
+        {
+            if (Manager->PhysicsEngine) return Manager->PhysicsEngine;
+        }
+        if (WorldCtx)
+        {
+            if (UWorld* World = WorldCtx->GetWorld())
+            {
+                for (TActorIterator<AAMjManager> It(World); It; ++It)
+                {
+                    if (It->PhysicsEngine) return It->PhysicsEngine;
+                }
+            }
+        }
+        return nullptr;
+    }
+}
 
 UMjBody::UMjBody()
 {
@@ -53,11 +78,16 @@ void UMjBody::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponen
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 
-    if (m_IsSetup && mocap && m_MocapPos && m_MocapQuat)
-    {
-        MjUtils::UEToMjPosition(GetComponentLocation(), m_MocapPos);
-        MjUtils::UEToMjRotation(GetComponentQuat(), m_MocapQuat);
-    }
+    if (!m_IsSetup || !mocap || m_BodyView.id < 0) return;
+
+    UMjPhysicsEngine* Engine = GetEngine(this);
+    if (!Engine) return;
+
+    double MjPos[3];
+    double MjQuat[4];
+    MjUtils::UEToMjPosition(GetComponentLocation(), MjPos);
+    MjUtils::UEToMjRotation(GetComponentQuat(), MjQuat);
+    Engine->SubmitMocapPose(m_BodyView.id, MjPos, MjQuat);
 }
 
 void UMjBody::ApplyRenderState(const FMjRenderSnapshot& Snap)
@@ -284,15 +314,6 @@ void UMjBody::Bind(mjModel* Model, mjData* Data, const FString& Prefix)
             SetComponentTickEnabled(false);
         }
 
-        if (mocap && m_ID >= 0)
-        {
-            int mocapid = Model->body_mocapid[m_ID];
-            if (mocapid >= 0)
-            {
-                 m_MocapPos = Data->mocap_pos + 3 * mocapid;
-                 m_MocapQuat = Data->mocap_quat + 4 * mocapid;
-            }
-        }
     }
 
 	TArray<USceneComponent*> AllChildren;
@@ -366,64 +387,51 @@ FMuJoCoSpatialVelocity UMjBody::GetSpatialVelocity() const
 
 void UMjBody::ApplyForce(FVector force, FVector Torque)
 {
-    if (m_BodyView.id < 0 || !m_BodyView.xfrc_applied) return;
-    // xfrc_applied layout: [torque_x, torque_y, torque_z, force_x, force_y, force_z] in MuJoCo frame
-    // Convert UE (cm, Y-flip) -> MuJoCo (m, right-hand)
-    const float InvScale = 0.01f; // cm -> m
-    mjtNum* xfrc = m_BodyView.xfrc_applied;
-    // Torque: UE X -> Mj X, UE Y -> -Mj Y, UE Z -> Mj Z
-    xfrc[0] = (mjtNum)(Torque.X);
-    xfrc[1] = (mjtNum)(-Torque.Y);
-    xfrc[2] = (mjtNum)(Torque.Z);
-    // force: same convention
-    xfrc[3] = (mjtNum)(force.X * InvScale);
-    xfrc[4] = (mjtNum)(-force.Y * InvScale);
-    xfrc[5] = (mjtNum)(force.Z * InvScale);
+    if (m_BodyView.id < 0) return;
+    UMjPhysicsEngine* Engine = GetEngine(this);
+    if (!Engine) return;
+
+    const double InvScale = 0.01; // cm -> m
+    double Xfrc[6];
+    Xfrc[0] = static_cast<double>(Torque.X);
+    Xfrc[1] = static_cast<double>(-Torque.Y);
+    Xfrc[2] = static_cast<double>(Torque.Z);
+    Xfrc[3] = static_cast<double>(force.X) * InvScale;
+    Xfrc[4] = static_cast<double>(-force.Y) * InvScale;
+    Xfrc[5] = static_cast<double>(force.Z) * InvScale;
+    Engine->SubmitWrench(m_BodyView.id, Xfrc);
 }
 
 void UMjBody::ClearForce()
 {
-    if (m_BodyView.id < 0 || !m_BodyView.xfrc_applied) return;
-    for (int i = 0; i < 6; ++i)
-        m_BodyView.xfrc_applied[i] = 0.0;
+    if (m_BodyView.id < 0) return;
+    if (UMjPhysicsEngine* Engine = GetEngine(this))
+    {
+        Engine->SubmitClearForce(m_BodyView.id);
+    }
 }
 
 bool UMjBody::IsAwake() const
 {
-    // body_awake: mjtSleepState — mjS_ASLEEP=0, mjS_AWAKE=1
-    if (m_BodyView.id < 0 || !m_BodyView._d) return true;  // unbound → treat as awake
+    if (m_BodyView.id < 0 || !m_BodyView._d) return true;
     return m_BodyView._d->body_awake[m_BodyView.id] != 0;
 }
 
 void UMjBody::Wake()
 {
-    if (m_BodyView.id < 0 || !m_BodyView._d || !m_BodyView._m) return;
-
-    m_BodyView._d->body_awake[m_BodyView.id] = 1;  // mjS_AWAKE
-
-    // Also wake the kinematic tree so the physics step propagates the wake.
-    int32 TreeId = m_BodyView._m->body_treeid[m_BodyView.id];
-    if (TreeId >= 0 && TreeId < m_BodyView._m->ntree)
+    if (m_BodyView.id < 0) return;
+    if (UMjPhysicsEngine* Engine = GetEngine(this))
     {
-        m_BodyView._d->tree_asleep[TreeId] = -1;  // <0 → awake
-        m_BodyView._d->tree_awake[TreeId]  = 1;
+        Engine->ApplyWakeBody(m_BodyView.id);
     }
 }
 
 void UMjBody::PutToSleep()
 {
-    if (m_BodyView.id < 0 || !m_BodyView._d || !m_BodyView._m) return;
-
-    m_BodyView._d->body_awake[m_BodyView.id] = 0;  // mjS_ASLEEP
-
-    // Also mark the kinematic tree as sleeping.
-    int32 TreeId = m_BodyView._m->body_treeid[m_BodyView.id];
-    if (TreeId >= 0 && TreeId < m_BodyView._m->ntree)
+    if (m_BodyView.id < 0) return;
+    if (UMjPhysicsEngine* Engine = GetEngine(this))
     {
-        // tree_asleep >= 0 means the tree is sleeping (value is an index in the sleep cycle).
-        if (m_BodyView._d->tree_asleep[TreeId] < 0)
-            m_BodyView._d->tree_asleep[TreeId] = 0;
-        m_BodyView._d->tree_awake[TreeId] = 0;
+        Engine->ApplySleepBody(m_BodyView.id);
     }
 }
 

--- a/Source/URLab/Private/MuJoCo/Components/Bodies/MjBody.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Bodies/MjBody.cpp
@@ -28,6 +28,7 @@
 #include "MuJoCo/Components/Geometry/MjSite.h"
 #include "MuJoCo/Components/Joints/MjJoint.h"
 #include "MuJoCo/Core/Spec/MjSpecWrapper.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Utils/MjXmlUtils.h"
 #include "MuJoCo/Utils/MjUtils.h"
 #include "MuJoCo/Utils/MjOrientationUtils.h"
@@ -52,43 +53,50 @@ void UMjBody::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponen
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 
-    if (m_IsSetup)
+    if (m_IsSetup && mocap && m_MocapPos && m_MocapQuat)
     {
-        if (mocap && m_MocapPos && m_MocapQuat)
-        {
-        	MjUtils::UEToMjPosition(GetComponentLocation(), m_MocapPos);
-        	MjUtils::UEToMjRotation(GetComponentQuat(), m_MocapQuat);
-        }
-        else
-        {
-            if (!m_BodyView.xpos || !m_BodyView.xquat)
-            {
-                UE_LOG(LogURLabBind, Warning, TEXT("MjBody::TickComponent - Body '%s' has null xpos/xquat (bind failed). Disabling tick."), *GetName());
-                m_IsSetup = false;
-                SetComponentTickEnabled(false);
-                return;
-            }
-
-            // Thread safety: xpos/xquat reads are lock-free. On x86-64, aligned double
-            // reads are atomic (no tearing). Worst case is a 1-frame position/rotation
-            // desync which is visually imperceptible. This matches MuJoCo Simulate's
-            // own threading model.
-    	    FVector MuJoCoWorldPos = MjUtils::MjToUEPosition(m_BodyView.xpos);
-    	    FQuat MuJoCoWorldQuat = MjUtils::MjToUERotation(m_BodyView.xquat);
-    	    
-            FVector CorrectedPos = MuJoCoWorldPos;
-            
-            // Apply mesh pivot offset correction ONLY if QuickConverted (Unreal -> MuJoCo flow pivot issues)
-            if (bIsQuickConverted)
-            {
-    	        // MuJoCo's xpos is at body center, but UE mesh may have off-center pivot
-        	    FVector OffsetVector = MuJoCoWorldQuat.RotateVector(m_MeshPivotOffset);
-        	    CorrectedPos = MuJoCoWorldPos - OffsetVector;
-            }
-    
-    	    SetWorldLocationAndRotation(CorrectedPos, MuJoCoWorldQuat);
-        }
+        MjUtils::UEToMjPosition(GetComponentLocation(), m_MocapPos);
+        MjUtils::UEToMjRotation(GetComponentQuat(), m_MocapQuat);
     }
+}
+
+void UMjBody::ApplyRenderState(const FMjRenderSnapshot& Snap)
+{
+    if (!m_IsSetup || mocap)
+    {
+        return;
+    }
+
+    const int32 Id = m_BodyView.id;
+    if (Id < 0)
+    {
+        return;
+    }
+
+    const int32 PosIdx  = Id * 3;
+    const int32 QuatIdx = Id * 4;
+    if (Snap.XPos.Num() <= PosIdx + 2 || Snap.XQuat.Num() <= QuatIdx + 3)
+    {
+        UE_LOG(LogURLabBind, Warning,
+            TEXT("MjBody::ApplyRenderState - Body '%s' (id=%d) out of range "
+                 "of snapshot (XPos=%d, XQuat=%d). Disabling updates."),
+            *GetName(), Id, Snap.XPos.Num(), Snap.XQuat.Num());
+        m_IsSetup = false;
+        return;
+    }
+
+    const FVector MuJoCoWorldPos  = MjUtils::MjToUEPosition(&Snap.XPos[PosIdx]);
+    const FQuat   MuJoCoWorldQuat = MjUtils::MjToUERotation(&Snap.XQuat[QuatIdx]);
+
+    FVector CorrectedPos = MuJoCoWorldPos;
+
+    if (bIsQuickConverted)
+    {
+        const FVector OffsetVector = MuJoCoWorldQuat.RotateVector(m_MeshPivotOffset);
+        CorrectedPos = MuJoCoWorldPos - OffsetVector;
+    }
+
+    SetWorldLocationAndRotation(CorrectedPos, MuJoCoWorldQuat);
 }
 
 

--- a/Source/URLab/Private/MuJoCo/Components/Deformable/MjFlexcomp.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Deformable/MjFlexcomp.cpp
@@ -36,6 +36,9 @@
 #include "Materials/MaterialInstanceDynamic.h"
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Core/MjPhysicsEngine.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
+#include "EngineUtils.h"
+#include "MuJoCo/Core/MjPhysicsEngine.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 #include "Misc/ScopeTryLock.h"
@@ -812,26 +815,42 @@ void UMjFlexcomp::UpdateProceduralMesh()
         ? DynamicMesh->GetAttachParent()->GetComponentTransform()
         : FTransform::Identity;
 
-    // Read welded flex positions under the physics mutex to avoid torn reads.
+    // Read welded flex positions from the engine snapshot — coherent across
+    // bodies in this UE frame and never blocks the physics step.
     TArray<FVector> WeldedPositions;
     WeldedPositions.SetNum(FlexVertNum);
 
-    AAMjManager* Manager = AAMjManager::GetManager();
-    UMjPhysicsEngine* Engine = Manager ? Manager->PhysicsEngine : nullptr;
-
+    UMjPhysicsEngine* Engine = nullptr;
+    if (AAMjManager* Manager = AAMjManager::GetManager())
     {
-        FScopeTryLock ScopeLock(Engine ? &Engine->CallbackMutex : nullptr);
-        if (Engine && !ScopeLock.IsLocked())
+        Engine = Manager->PhysicsEngine;
+    }
+    if (!Engine)
+    {
+        if (UWorld* World = GetWorld())
         {
-            return;
+            for (TActorIterator<AAMjManager> It(World); It; ++It)
+            {
+                if (It->PhysicsEngine) { Engine = It->PhysicsEngine; break; }
+            }
         }
+    }
+    if (!Engine) return;
+
+    bool bOk = false;
+    Engine->WithRenderState([&](const FMjRenderSnapshot& Snap)
+    {
+        const int32 NeededFloats = (FlexVertAdr + FlexVertNum) * 3;
+        if (Snap.FlexvertXPos.Num() < NeededFloats) return;
         for (int32 i = 0; i < FlexVertNum; i++)
         {
             const int32 Idx = (FlexVertAdr + i) * 3;
-            const FVector WorldPos = MjUtils::MjToUEPosition(&m_Data->flexvert_xpos[Idx]);
+            const FVector WorldPos = MjUtils::MjToUEPosition(&Snap.FlexvertXPos[Idx]);
             WeldedPositions[i] = ParentTransform.InverseTransformPosition(WorldPos);
         }
-    }
+        bOk = true;
+    });
+    if (!bOk) return;
 
     DynamicMesh->EditMesh([&](UE::Geometry::FDynamicMesh3& Mesh)
     {

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
@@ -22,6 +22,9 @@
 
 #include "MuJoCo/Components/Geometry/MjGeom.h"
 #include "Components/StaticMeshComponent.h"
+#include "MuJoCo/Core/AMjManager.h"
+#include "MuJoCo/Core/MjPhysicsEngine.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Utils/MjXmlUtils.h"
 #include "MuJoCo/Utils/MjUtils.h"
 #include "MuJoCo/Utils/MjOrientationUtils.h"
@@ -296,27 +299,48 @@ void UMjGeom::Bind(mjModel* Model, mjData* Data, const FString& Prefix)
 
 void UMjGeom::UpdateGlobalTransform()
 {
-    if (m_GeomView._m && m_GeomView._d && m_GeomView.id >= 0)
+    const int32 Id = m_GeomView.id;
+    if (Id < 0) return;
+
+    AAMjManager* Manager = AAMjManager::GetManager();
+    if (!Manager || !Manager->PhysicsEngine) return;
+
+    Manager->PhysicsEngine->WithRenderState([this, Id](const FMjRenderSnapshot& Snap)
     {
-        // Get world position from MuJoCo
-        FVector WorldPos = MjUtils::MjToUEPosition(m_GeomView.xpos);
-        FQuat WorldRot;
+        const int32 PosIdx = Id * 3;
+        const int32 MatIdx = Id * 9;
+        if (Snap.GeomXPos.Num() <= PosIdx + 2 || Snap.GeomXMat.Num() <= MatIdx + 8)
+        {
+            return;
+        }
+        const FVector WorldPos = MjUtils::MjToUEPosition(&Snap.GeomXPos[PosIdx]);
         mjtNum quat[4];
-        mju_mat2Quat(quat, m_GeomView.xmat);
-        WorldRot = MjUtils::MjToUERotation(quat);
-        
+        mju_mat2Quat(quat, const_cast<mjtNum*>(&Snap.GeomXMat[MatIdx]));
+        const FQuat WorldRot = MjUtils::MjToUERotation(quat);
+
         SetWorldLocation(WorldPos);
         SetWorldRotation(WorldRot);
-    }
+    });
 }
 
 FVector UMjGeom::GetWorldLocation() const
 {
-    if (m_GeomView._m && m_GeomView._d && m_GeomView.id >= 0)
+    const int32 Id = m_GeomView.id;
+    if (Id < 0) return GetComponentLocation();
+
+    AAMjManager* Manager = AAMjManager::GetManager();
+    if (!Manager || !Manager->PhysicsEngine) return GetComponentLocation();
+
+    FVector Out = GetComponentLocation();
+    Manager->PhysicsEngine->WithRenderState([Id, &Out](const FMjRenderSnapshot& Snap)
     {
-        return MjUtils::MjToUEPosition(m_GeomView.xpos);
-    }
-    return GetComponentLocation();
+        const int32 PosIdx = Id * 3;
+        if (Snap.GeomXPos.Num() > PosIdx + 2)
+        {
+            Out = MjUtils::MjToUEPosition(&Snap.GeomXPos[PosIdx]);
+        }
+    });
+    return Out;
 }
 void UMjGeom::SetFriction(float NewFriction)
 {

--- a/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/Geometry/MjGeom.cpp
@@ -27,6 +27,29 @@
 #include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Utils/MjXmlUtils.h"
 #include "MuJoCo/Utils/MjUtils.h"
+#include "EngineUtils.h"
+
+namespace
+{
+    UMjPhysicsEngine* ResolveEngine(const UObject* WorldCtx)
+    {
+        if (AAMjManager* Manager = AAMjManager::GetManager())
+        {
+            if (Manager->PhysicsEngine) return Manager->PhysicsEngine;
+        }
+        if (WorldCtx)
+        {
+            if (UWorld* World = WorldCtx->GetWorld())
+            {
+                for (TActorIterator<AAMjManager> It(World); It; ++It)
+                {
+                    if (It->PhysicsEngine) return It->PhysicsEngine;
+                }
+            }
+        }
+        return nullptr;
+    }
+}
 #include "MuJoCo/Utils/MjOrientationUtils.h"
 #include "XmlNode.h"
 #include "Utils/URLabLogging.h"
@@ -302,10 +325,10 @@ void UMjGeom::UpdateGlobalTransform()
     const int32 Id = m_GeomView.id;
     if (Id < 0) return;
 
-    AAMjManager* Manager = AAMjManager::GetManager();
-    if (!Manager || !Manager->PhysicsEngine) return;
+    UMjPhysicsEngine* Engine = ResolveEngine(this);
+    if (!Engine) return;
 
-    Manager->PhysicsEngine->WithRenderState([this, Id](const FMjRenderSnapshot& Snap)
+    Engine->WithRenderState([this, Id](const FMjRenderSnapshot& Snap)
     {
         const int32 PosIdx = Id * 3;
         const int32 MatIdx = Id * 9;
@@ -328,11 +351,11 @@ FVector UMjGeom::GetWorldLocation() const
     const int32 Id = m_GeomView.id;
     if (Id < 0) return GetComponentLocation();
 
-    AAMjManager* Manager = AAMjManager::GetManager();
-    if (!Manager || !Manager->PhysicsEngine) return GetComponentLocation();
+    UMjPhysicsEngine* Engine = ResolveEngine(this);
+    if (!Engine) return GetComponentLocation();
 
     FVector Out = GetComponentLocation();
-    Manager->PhysicsEngine->WithRenderState([Id, &Out](const FMjRenderSnapshot& Snap)
+    Engine->WithRenderState([Id, &Out](const FMjRenderSnapshot& Snap)
     {
         const int32 PosIdx = Id * 3;
         if (Snap.GeomXPos.Num() > PosIdx + 2)

--- a/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
@@ -23,6 +23,7 @@
 #include "MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h"
 #include "MuJoCo/Components/Bodies/MjBody.h"
 #include "MuJoCo/Components/Joints/MjFreeJoint.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Utils/MjUtils.h"
 
 #include "MuJoCo/Components/Geometry/MjGeom.h"
@@ -280,35 +281,38 @@ void UMjQuickConvertComponent::PostSetup(mjModel* model, mjData* data) {
 
 
 
-void UMjQuickConvertComponent::UpdateUETransform() {
-
-    if (!m_model || !m_data) {
-        return;
-    }
-
-    if (bDrivenByUnreal && MocapPos && MocapQuat)
-    {
-         MjUtils::UEToMjPosition(m_actor->GetActorLocation(), MocapPos);
-         MjUtils::UEToMjRotation(m_actor->GetActorQuat(), MocapQuat);
-         return;
-    }
-        FVector _pos = MjUtils::MjToUEPosition(m_CreatedBody->GetBodyView().xpos);
-        FQuat _quat = MjUtils::MjToUERotation(m_CreatedBody->GetBodyView().xquat);
-
-        m_actor->SetActorRotation(_quat);
-        m_actor->SetActorLocation(_pos);
-}
-
 void UMjQuickConvertComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) {
     Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-
-    if (!bDrivenByUnreal && m_CreatedBody)
-    {
-        UpdateUETransform();
-    }
 
     if (m_debug_meshes)
     {
         DrawDebugCollision();
     }
+}
+
+void UMjQuickConvertComponent::ApplyRenderState(const FMjRenderSnapshot& Snap)
+{
+    if (!m_model || !m_data || !m_CreatedBody || !m_actor || bDrivenByUnreal)
+    {
+        return;
+    }
+
+    const int32 Id = m_CreatedBody->GetBodyView().id;
+    if (Id < 0)
+    {
+        return;
+    }
+
+    const int32 PosIdx  = Id * 3;
+    const int32 QuatIdx = Id * 4;
+    if (Snap.XPos.Num() <= PosIdx + 2 || Snap.XQuat.Num() <= QuatIdx + 3)
+    {
+        return;
+    }
+
+    const FVector Pos  = MjUtils::MjToUEPosition(&Snap.XPos[PosIdx]);
+    const FQuat   Quat = MjUtils::MjToUERotation(&Snap.XQuat[QuatIdx]);
+
+    m_actor->SetActorRotation(Quat);
+    m_actor->SetActorLocation(Pos);
 }

--- a/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
+++ b/Source/URLab/Private/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.cpp
@@ -23,8 +23,33 @@
 #include "MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h"
 #include "MuJoCo/Components/Bodies/MjBody.h"
 #include "MuJoCo/Components/Joints/MjFreeJoint.h"
+#include "MuJoCo/Core/AMjManager.h"
+#include "MuJoCo/Core/MjPhysicsEngine.h"
 #include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Utils/MjUtils.h"
+#include "EngineUtils.h"
+
+namespace
+{
+    UMjPhysicsEngine* GetEngine(const UObject* WorldCtx)
+    {
+        if (AAMjManager* Manager = AAMjManager::GetManager())
+        {
+            if (Manager->PhysicsEngine) return Manager->PhysicsEngine;
+        }
+        if (WorldCtx)
+        {
+            if (UWorld* World = WorldCtx->GetWorld())
+            {
+                for (TActorIterator<AAMjManager> It(World); It; ++It)
+                {
+                    if (It->PhysicsEngine) return It->PhysicsEngine;
+                }
+            }
+        }
+        return nullptr;
+    }
+}
 
 #include "MuJoCo/Components/Geometry/MjGeom.h"
 
@@ -283,6 +308,20 @@ void UMjQuickConvertComponent::PostSetup(mjModel* model, mjData* data) {
 
 void UMjQuickConvertComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) {
     Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (bDrivenByUnreal && m_CreatedBody && m_actor)
+    {
+        UMjPhysicsEngine* Engine = GetEngine(this);
+        const int32 BodyId = m_CreatedBody->GetBodyView().id;
+        if (Engine && BodyId >= 0)
+        {
+            double Pos[3];
+            double Quat[4];
+            MjUtils::UEToMjPosition(m_actor->GetActorLocation(), Pos);
+            MjUtils::UEToMjRotation(m_actor->GetActorQuat(), Quat);
+            Engine->SubmitMocapPose(BodyId, Pos, Quat);
+        }
+    }
 
     if (m_debug_meshes)
     {

--- a/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/AMjManager.cpp
@@ -23,6 +23,7 @@
 
 #include "MuJoCo/Core/AMjManager.h"
 #include "MuJoCo/Core/MjPhysicsEngine.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Core/MjDebugVisualizer.h"
 #include "MuJoCo/Net/MjNetworkManager.h"
 #include "MuJoCo/Input/MjInputHandler.h"
@@ -286,8 +287,32 @@ void AAMjManager::EndPlay(const EEndPlayReason::Type EndPlayReason) {
 
 void AAMjManager::Tick(float DeltaTime) {
     Super::Tick(DeltaTime);
-    // Hotkey processing handled by UMjInputHandler::TickComponent
-    // Debug drawing handled by UMjDebugVisualizer::TickComponent
+
+    if (!PhysicsEngine || !PhysicsEngine->IsInitialized())
+    {
+        return;
+    }
+
+    const TArray<AMjArticulation*> Arts          = PhysicsEngine->GetAllArticulations();
+    const TArray<UMjQuickConvertComponent*> Quicks = PhysicsEngine->GetAllQuickComponents();
+
+    PhysicsEngine->WithRenderState([&](const FMjRenderSnapshot& Snap)
+    {
+        for (AMjArticulation* Art : Arts)
+        {
+            if (Art)
+            {
+                Art->ApplyRenderState(Snap);
+            }
+        }
+        for (UMjQuickConvertComponent* Quick : Quicks)
+        {
+            if (Quick)
+            {
+                Quick->ApplyRenderState(Snap);
+            }
+        }
+    });
 }
 
 AAMjManager* AAMjManager::GetManager()

--- a/Source/URLab/Private/MuJoCo/Core/MjArticulation.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjArticulation.cpp
@@ -21,6 +21,7 @@
 // CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
 
 #include "MuJoCo/Core/MjArticulation.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
 #include "MuJoCo/Core/Spec/MjSpecWrapper.h"
 #include "MuJoCo/Components/Controllers/MjArticulationController.h"
 #include "MuJoCo/Input/MjTwistController.h"
@@ -1080,7 +1081,7 @@ TArray<float> AMjArticulation::GetSensorReading(const FString& SensorName) const
 void AMjArticulation::Tick(float DeltaTime)
 {
     Super::Tick(DeltaTime);
-    
+
     if (bDrawDebugCollision)
     {
         DrawDebugCollision();
@@ -1092,6 +1093,19 @@ void AMjArticulation::Tick(float DeltaTime)
     if (bDrawDebugSites)
     {
         DrawDebugSites();
+    }
+}
+
+void AMjArticulation::ApplyRenderState(const FMjRenderSnapshot& Snap)
+{
+    TArray<UMjBody*> Bodies;
+    GetRuntimeComponents<UMjBody>(Bodies);
+    for (UMjBody* Body : Bodies)
+    {
+        if (Body)
+        {
+            Body->ApplyRenderState(Snap);
+        }
     }
 }
 

--- a/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
@@ -418,6 +418,11 @@ void UMjPhysicsEngine::RunMujocoAsync()
                 {
                     OnPostStep(m_model, m_data);
                 }
+
+                // Publish a coherent render snapshot for game-thread
+                // consumers. Inside the same CallbackMutex scope so the
+                // snapshot reflects the m_data that was just stepped.
+                PushRenderState();
             } // FScopeLock released here
 
             // Spin-wait for precise timing at small timesteps
@@ -474,6 +479,11 @@ void UMjPhysicsEngine::StepSync(int32 NumSteps)
     {
         mj_step(m_model, m_data);
     }
+
+    // Publish a render snapshot for the sync step path too. Keeps the
+    // render flow uniform across async and sync stepping (RPC, replay
+    // scrub, custom step handlers).
+    PushRenderState();
 
     bIsPaused = bWasPaused;
 }
@@ -606,4 +616,106 @@ void UMjPhysicsEngine::ClearCallbacks()
 {
     PreStepCallbacks.Empty();
     PostStepCallbacks.Empty();
+}
+
+// =============================================================================
+// RenderState pump
+//
+// Producer (PushRenderState) runs on the stepping thread inside the
+// CallbackMutex region right after mj_step + OnPostStep, then briefly
+// takes RenderStateMutex to publish a fresh frame. Consumers
+// (WithRenderState) take RenderStateMutex for the duration of their
+// visitor, so every consumer in one UE frame sees the same coherent
+// physics frame.
+//
+// Lock ordering invariant: CallbackMutex (outer) -> RenderStateMutex
+// (inner). The consumer never takes CallbackMutex.
+// =============================================================================
+
+namespace
+{
+    template <typename T>
+    static void ResizeIfDifferent(TArray<T>& Array, int32 RequiredNum)
+    {
+        if (Array.Num() != RequiredNum)
+        {
+            Array.SetNumUninitialized(RequiredNum);
+        }
+    }
+
+    template <typename T>
+    static void CopyArray(TArray<T>& Dst, const void* Src, int32 Count)
+    {
+        // T is deduced from Dst only. Src is type-erased so MuJoCo's
+        // raw `int*` / `mjtNum*` pointers don't have to match T's
+        // typedef chain exactly; sizeof(T) drives the byte count.
+        if (!Src || Count <= 0)
+        {
+            Dst.Reset();
+            return;
+        }
+        ResizeIfDifferent(Dst, Count);
+        FMemory::Memcpy(Dst.GetData(), Src, sizeof(T) * static_cast<SIZE_T>(Count));
+    }
+}
+
+void UMjPhysicsEngine::PushRenderState()
+{
+    if (!m_model || !m_data)
+    {
+        return;
+    }
+
+    FScopeLock Lock(&RenderStateMutex);
+
+    const int32 NBody        = m_model->nbody;
+    const int32 NGeom        = m_model->ngeom;
+    const int32 NSite        = m_model->nsite;
+    const int32 NCam         = m_model->ncam;
+    const int32 NQ           = m_model->nq;
+    const int32 NV           = m_model->nv;
+    const int32 NU           = m_model->nu;
+    const int32 NSensorData  = m_model->nsensordata;
+    const int32 NTree        = m_model->ntree;
+    const int32 NFlexvert    = m_model->nflexvert;
+
+    // Body kinematics.
+    CopyArray(RenderSnapshot.XPos,        m_data->xpos,         NBody * 3);
+    CopyArray(RenderSnapshot.XQuat,       m_data->xquat,        NBody * 4);
+    CopyArray(RenderSnapshot.CVel,        m_data->cvel,         NBody * 6);
+    CopyArray(RenderSnapshot.XfrcApplied, m_data->xfrc_applied, NBody * 6);
+
+    // Geoms / sites / cameras.
+    CopyArray(RenderSnapshot.GeomXPos,    m_data->geom_xpos,    NGeom * 3);
+    CopyArray(RenderSnapshot.GeomXMat,    m_data->geom_xmat,    NGeom * 9);
+    CopyArray(RenderSnapshot.SiteXPos,    m_data->site_xpos,    NSite * 3);
+    CopyArray(RenderSnapshot.SiteXMat,    m_data->site_xmat,    NSite * 9);
+    CopyArray(RenderSnapshot.CamXPos,     m_data->cam_xpos,     NCam * 3);
+    CopyArray(RenderSnapshot.CamXMat,     m_data->cam_xmat,     NCam * 9);
+
+    // Joint / actuator / sensor state.
+    CopyArray(RenderSnapshot.QPos,          m_data->qpos,           NQ);
+    CopyArray(RenderSnapshot.QVel,          m_data->qvel,           NV);
+    CopyArray(RenderSnapshot.QAcc,          m_data->qacc,           NV);
+    CopyArray(RenderSnapshot.ActuatorForce, m_data->actuator_force, NU);
+    CopyArray(RenderSnapshot.SensorData,    m_data->sensordata,     NSensorData);
+
+    // Sleep state.
+    CopyArray(RenderSnapshot.BodyAwake,  m_data->body_awake,  NBody);
+    CopyArray(RenderSnapshot.TreeAsleep, m_data->tree_asleep, NTree);
+    CopyArray(RenderSnapshot.TreeAwake,  m_data->tree_awake,  NTree);
+
+    // Flex deformable state.
+    CopyArray(RenderSnapshot.FlexvertXPos, m_data->flexvert_xpos, NFlexvert * 3);
+
+    // Metadata.
+    RenderSnapshot.SimTime = m_data->time;
+    ++RenderSnapshot.FrameId;
+}
+
+void UMjPhysicsEngine::WithRenderState(
+    TFunctionRef<void(const FMjRenderSnapshot&)> Visitor)
+{
+    FScopeLock Lock(&RenderStateMutex);
+    Visitor(RenderSnapshot);
 }

--- a/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
@@ -401,6 +401,8 @@ void UMjPhysicsEngine::RunMujocoAsync()
                     if (Art) Art->ApplyControls();
                 }
 
+                DrainCommands();
+
                 if (!bIsPaused)
                 {
                     if (CustomStepHandler)
@@ -477,6 +479,7 @@ void UMjPhysicsEngine::StepSync(int32 NumSteps)
 
     for (int32 i = 0; i < NumSteps; ++i)
     {
+        DrainCommands();
         mj_step(m_model, m_data);
     }
 
@@ -718,4 +721,102 @@ void UMjPhysicsEngine::WithRenderState(
 {
     FScopeLock Lock(&RenderStateMutex);
     Visitor(RenderSnapshot);
+}
+
+// =============================================================================
+// Command channel (UE -> MuJoCo)
+//
+// Game-thread writers enqueue under CommandMutex; the stepping thread drains
+// inside CallbackMutex right before mj_step. Last-write-wins per body per
+// drain.
+// =============================================================================
+
+void UMjPhysicsEngine::SubmitMocapPose(int32 BodyId, const double Pos[3], const double Quat[4])
+{
+    if (BodyId < 0) return;
+    FScopeLock Lock(&CommandMutex);
+    FMocapPose& Slot = PendingCommands.MocapPoses.FindOrAdd(BodyId);
+    FMemory::Memcpy(Slot.Pos,  Pos,  sizeof(Slot.Pos));
+    FMemory::Memcpy(Slot.Quat, Quat, sizeof(Slot.Quat));
+}
+
+void UMjPhysicsEngine::SubmitWrench(int32 BodyId, const double Xfrc[6])
+{
+    if (BodyId < 0) return;
+    FScopeLock Lock(&CommandMutex);
+    FWrench& Slot = PendingCommands.WrenchSets.FindOrAdd(BodyId);
+    FMemory::Memcpy(Slot.Xfrc, Xfrc, sizeof(Slot.Xfrc));
+    PendingCommands.WrenchClears.Remove(BodyId);
+}
+
+void UMjPhysicsEngine::SubmitClearForce(int32 BodyId)
+{
+    if (BodyId < 0) return;
+    FScopeLock Lock(&CommandMutex);
+    PendingCommands.WrenchSets.Remove(BodyId);
+    PendingCommands.WrenchClears.Add(BodyId);
+}
+
+void UMjPhysicsEngine::ApplyWakeBody(int32 BodyId)
+{
+    if (!m_model || !m_data || BodyId < 0 || BodyId >= m_model->nbody) return;
+    FScopeLock Lock(&CallbackMutex);
+    m_data->body_awake[BodyId] = 1;
+    const int32 TreeId = m_model->body_treeid[BodyId];
+    if (TreeId >= 0 && TreeId < m_model->ntree)
+    {
+        m_data->tree_asleep[TreeId] = -1;
+        m_data->tree_awake[TreeId]  = 1;
+    }
+}
+
+void UMjPhysicsEngine::ApplySleepBody(int32 BodyId)
+{
+    if (!m_model || !m_data || BodyId < 0 || BodyId >= m_model->nbody) return;
+    FScopeLock Lock(&CallbackMutex);
+    m_data->body_awake[BodyId] = 0;
+    const int32 TreeId = m_model->body_treeid[BodyId];
+    if (TreeId >= 0 && TreeId < m_model->ntree)
+    {
+        if (m_data->tree_asleep[TreeId] < 0)
+            m_data->tree_asleep[TreeId] = 0;
+        m_data->tree_awake[TreeId] = 0;
+    }
+}
+
+void UMjPhysicsEngine::DrainCommands()
+{
+    if (!m_model || !m_data) return;
+
+    FCommandQueue Local;
+    {
+        FScopeLock Lock(&CommandMutex);
+        if (PendingCommands.IsEmpty()) return;
+        Local = MoveTemp(PendingCommands);
+        PendingCommands = FCommandQueue();
+    }
+
+    const int32 NBody = m_model->nbody;
+
+    for (const TPair<int32, FMocapPose>& Pair : Local.MocapPoses)
+    {
+        const int32 BodyId = Pair.Key;
+        if (BodyId < 0 || BodyId >= NBody) continue;
+        const int32 MocapId = m_model->body_mocapid[BodyId];
+        if (MocapId < 0) continue;
+        FMemory::Memcpy(m_data->mocap_pos  + 3 * MocapId, Pair.Value.Pos,  sizeof(Pair.Value.Pos));
+        FMemory::Memcpy(m_data->mocap_quat + 4 * MocapId, Pair.Value.Quat, sizeof(Pair.Value.Quat));
+    }
+
+    for (const TPair<int32, FWrench>& Pair : Local.WrenchSets)
+    {
+        const int32 BodyId = Pair.Key;
+        if (BodyId < 0 || BodyId >= NBody) continue;
+        FMemory::Memcpy(m_data->xfrc_applied + 6 * BodyId, Pair.Value.Xfrc, sizeof(Pair.Value.Xfrc));
+    }
+    for (int32 BodyId : Local.WrenchClears)
+    {
+        if (BodyId < 0 || BodyId >= NBody) continue;
+        FMemory::Memzero(m_data->xfrc_applied + 6 * BodyId, sizeof(double) * 6);
+    }
 }

--- a/Source/URLab/Public/MuJoCo/Components/Bodies/MjBody.h
+++ b/Source/URLab/Public/MuJoCo/Components/Bodies/MjBody.h
@@ -208,9 +208,6 @@ protected:
 
 private:
 	BodyView m_BodyView;
-    
-    mjtNum* m_MocapPos = nullptr;
-    mjtNum* m_MocapQuat = nullptr;
 
 	bool m_IsSetup = false;
     

--- a/Source/URLab/Public/MuJoCo/Components/Bodies/MjBody.h
+++ b/Source/URLab/Public/MuJoCo/Components/Bodies/MjBody.h
@@ -120,10 +120,14 @@ public:
 
 
 public:
-    /** @brief Called every frame. */
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
 	                           FActorComponentTickFunction* ThisTickFunction) override;
-    
+
+    /** @brief Applies the body's world transform from the engine's
+     *  per-step render snapshot. Driven by AAMjManager so every body
+     *  in one UE frame samples the same physics frame. */
+    void ApplyRenderState(const struct FMjRenderSnapshot& Snap);
+
 	void Setup(USceneComponent* Parent, mjsBody* ParentBody, FMujocoSpecWrapper* Wrapper);
     
     /**

--- a/Source/URLab/Public/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h
+++ b/Source/URLab/Public/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h
@@ -133,15 +133,16 @@ public:
 protected:
     /** @brief Called when the game starts. */
 	virtual void BeginPlay() override;
-    
+
     /** @brief Called when the game ends. */
     virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
     void DrawDebugCollision();
 
-    void UpdateUETransform();
-
-public:	
+public:
     /** @brief Called every frame. */
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    /** @brief Applies this body's transform from the engine snapshot to the owning actor. */
+    void ApplyRenderState(const struct FMjRenderSnapshot& Snap);
 };

--- a/Source/URLab/Public/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h
+++ b/Source/URLab/Public/MuJoCo/Components/QuickConvert/MjQuickConvertComponent.h
@@ -90,9 +90,6 @@ public:
         meta=(ToolTip="When true, writes the actor's world transform to MuJoCo as a mocap body every tick. The physics simulation does not feed back into Unreal."))
     bool bDrivenByUnreal = false;
 
-    double* MocapPos = nullptr;
-    double* MocapQuat = nullptr;
-
     /** @brief Friction parameters (sliding, torsional, rolling). Applied to all geoms created by this component. */
     UPROPERTY(EditAnywhere, Category="MuJoCo|Physics")
     FVector3d friction = {1.0, 1, 1};

--- a/Source/URLab/Public/MuJoCo/Core/MjArticulation.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjArticulation.h
@@ -403,8 +403,12 @@ protected:
     UPROPERTY(Transient)
     class UMjArticulationController* CachedController = nullptr;
 
-public:    
+public:
     virtual void Tick(float DeltaTime) override;
+
+    /** @brief Forwards the engine snapshot to every UMjBody under this
+     *  articulation so they all observe one coherent physics frame. */
+    void ApplyRenderState(const struct FMjRenderSnapshot& Snap);
 
     /** @brief Optional: Path to an existing MuJoCo XML to import. */
     UPROPERTY(EditAnywhere, Category = "MuJoCo Import")

--- a/Source/URLab/Public/MuJoCo/Core/MjPhysicsEngine.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjPhysicsEngine.h
@@ -270,6 +270,35 @@ public:
      */
     void WithRenderState(TFunctionRef<void(const FMjRenderSnapshot&)> Visitor);
 
+    // --- Command channel (UE -> MuJoCo) --------------------------------
+    //
+    // Game-thread writers (mocap, wrench, sleep) enqueue under
+    // CommandMutex; the stepping thread drains the queue inside
+    // CallbackMutex immediately before mj_step. This keeps every
+    // mjData mutation on the physics thread and avoids lock-free
+    // races on xfrc_applied / mocap_pos / body_awake.
+    //
+    // Last-write-wins per body per drain: re-submitting in one game
+    // frame collapses to the final value applied for the next step.
+
+    /** World-frame mocap pose for a mocap body, in MuJoCo coordinates. */
+    void SubmitMocapPose(int32 BodyId, const double Pos[3], const double Quat[4]);
+
+    /** Set xfrc_applied[body] = [tx, ty, tz, fx, fy, fz] (MuJoCo order). */
+    void SubmitWrench(int32 BodyId, const double Xfrc[6]);
+
+    /** Zero xfrc_applied for the body on the next drain. */
+    void SubmitClearForce(int32 BodyId);
+
+    /** Wake the body and its kinematic tree synchronously. Takes
+     *  CallbackMutex briefly so the write is observable to the caller
+     *  immediately (matches the user-facing one-shot contract). */
+    void ApplyWakeBody(int32 BodyId);
+
+    /** Put the body and its kinematic tree to sleep synchronously.
+     *  Takes CallbackMutex briefly (see ApplyWakeBody). */
+    void ApplySleepBody(int32 BodyId);
+
 private:
     TArray<FPhysicsCallback> PreStepCallbacks;
     TArray<FPhysicsCallback> PostStepCallbacks;
@@ -282,4 +311,40 @@ private:
 
     /** Engine-owned snapshot buffer. Sized on model load. */
     FMjRenderSnapshot RenderSnapshot;
+
+    // --- Command channel plumbing --------------------------------------
+
+    struct FMocapPose
+    {
+        double Pos[3];
+        double Quat[4];
+    };
+
+    struct FWrench
+    {
+        double Xfrc[6];
+    };
+
+    struct FCommandQueue
+    {
+        TMap<int32, FMocapPose> MocapPoses;
+        TMap<int32, FWrench>    WrenchSets;
+        TSet<int32>             WrenchClears;
+
+        bool IsEmpty() const
+        {
+            return MocapPoses.Num()   == 0
+                && WrenchSets.Num()   == 0
+                && WrenchClears.Num() == 0;
+        }
+    };
+
+    /** Independent of CallbackMutex / RenderStateMutex. Held only
+     *  briefly by Submit* and by the drain swap. */
+    FCriticalSection CommandMutex;
+    FCommandQueue PendingCommands;
+
+    /** Drains PendingCommands into m_data. Must be called by the
+     *  stepping thread while it already holds CallbackMutex. */
+    void DrainCommands();
 };

--- a/Source/URLab/Public/MuJoCo/Core/MjPhysicsEngine.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjPhysicsEngine.h
@@ -26,6 +26,7 @@
 #include "Components/ActorComponent.h"
 #include "mujoco/mujoco.h"
 #include "MuJoCo/Core/MjSimOptions.h"
+#include "MuJoCo/Core/MjRenderSnapshot.h"
 #include <functional>
 #include <atomic>
 #include "MjPhysicsEngine.generated.h"
@@ -247,7 +248,38 @@ public:
     /** @brief Clear all registered pre/post step callbacks. */
     void ClearCallbacks();
 
+    // --- RenderState pump (MuJoCo -> UE) -------------------------------
+
+    /**
+     * @brief Copies the live mjData into the engine-owned render
+     * snapshot. Bumps RenderSnapshot.FrameId. Must be called by the
+     * thread that just finished mj_step while it holds CallbackMutex.
+     *
+     * Lock ordering: CallbackMutex (outer) -> RenderStateMutex (inner).
+     * RenderStateMutex is taken inside this method only; callers must
+     * not hold it.
+     */
+    void PushRenderState();
+
+    /**
+     * @brief Runs the visitor against the latest render snapshot
+     * under RenderStateMutex. Holds the lock for the duration of the
+     * visitor, so the visitor must complete promptly and must not
+     * acquire CallbackMutex (or any lock that the producer takes
+     * under CallbackMutex).
+     */
+    void WithRenderState(TFunctionRef<void(const FMjRenderSnapshot&)> Visitor);
+
 private:
     TArray<FPhysicsCallback> PreStepCallbacks;
     TArray<FPhysicsCallback> PostStepCallbacks;
+
+    // --- RenderState plumbing ------------------------------------------
+
+    /** Guards RenderSnapshot. Inner to CallbackMutex on the producer
+     *  path; held alone on the consumer (game thread) path. */
+    FCriticalSection RenderStateMutex;
+
+    /** Engine-owned snapshot buffer. Sized on model load. */
+    FMjRenderSnapshot RenderSnapshot;
 };

--- a/Source/URLab/Public/MuJoCo/Core/MjRenderSnapshot.h
+++ b/Source/URLab/Public/MuJoCo/Core/MjRenderSnapshot.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Jonathan Embley-Riches. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// --- LEGAL DISCLAIMER ---
+// UnrealRoboticsLab is an independent software plugin. It is NOT affiliated with,
+// endorsed by, or sponsored by Epic Games, Inc. "Unreal" and "Unreal Engine" are
+// trademarks or registered trademarks of Epic Games, Inc. in the US and elsewhere.
+//
+// This plugin incorporates third-party software: MuJoCo (Apache 2.0),
+// CoACD (MIT), and libzmq (MPL 2.0). See ThirdPartyNotices.txt for details.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "mujoco/mujoco.h"
+
+/**
+ * Single-frame snapshot of MuJoCo state for game-thread consumers.
+ *
+ * Produced once per step on the physics thread inside
+ * UMjPhysicsEngine::PushRenderState while CallbackMutex is held.
+ * Consumed on the game thread via UMjPhysicsEngine::WithRenderState,
+ * which holds RenderStateMutex for the entire visitor body so every
+ * consumer in one UE frame observes the same coherent physics frame.
+ *
+ * All arrays are sized once on model load when nbody / ngeom /
+ * nsite / ncam / nq / nv / nu / nsensordata / ntree / nflexvert
+ * change; steady-state push reuses the existing storage.
+ *
+ * Lifetime is bound to the owning UMjPhysicsEngine.
+ */
+struct FMjRenderSnapshot
+{
+    // --- Body kinematics (visual update + APIs) -----------------------
+
+    /** Body world position. 3 * nbody (mjtNum). */
+    TArray<mjtNum> XPos;
+
+    /** Body world rotation (unit quaternion, mjtNum order w, x, y, z). 4 * nbody. */
+    TArray<mjtNum> XQuat;
+
+    /** Body spatial velocity (angular xyz, linear xyz, body frame). 6 * nbody. */
+    TArray<mjtNum> CVel;
+
+    /** Applied wrench on each body (linear xyz, angular xyz). 6 * nbody. */
+    TArray<mjtNum> XfrcApplied;
+
+    // --- Geoms / sites (debug viz, on-demand transform queries) -------
+
+    TArray<mjtNum> GeomXPos;       // 3 * ngeom
+    TArray<mjtNum> GeomXMat;       // 9 * ngeom
+    TArray<mjtNum> SiteXPos;       // 3 * nsite
+    TArray<mjtNum> SiteXMat;       // 9 * nsite
+
+    // --- Cameras (tracking modes, RPC camera lookups) -----------------
+
+    TArray<mjtNum> CamXPos;        // 3 * ncam
+    TArray<mjtNum> CamXMat;        // 9 * ncam
+
+    // --- Joint / actuator / sensor state ------------------------------
+
+    TArray<mjtNum> QPos;           // nq
+    TArray<mjtNum> QVel;           // nv
+    TArray<mjtNum> QAcc;           // nv
+    TArray<mjtNum> ActuatorForce;  // nu
+    TArray<mjtNum> SensorData;     // nsensordata
+
+    // --- Sleep state (IsAwake + debug viz) ----------------------------
+    //
+    // Stored as int because MuJoCo's body_awake is `int*` carrying
+    // mjtSleepState values (0 = asleep, 1 = awake). tree_asleep stores
+    // a signed sleep-cycle index (<0 = awake). tree_awake is 0/1.
+
+    TArray<int32>  BodyAwake;      // nbody
+    TArray<int32>  TreeAsleep;     // ntree
+    TArray<int32>  TreeAwake;      // ntree
+
+    // --- Flex deformable state (UMjFlexcomp) --------------------------
+
+    TArray<mjtNum> FlexvertXPos;   // 3 * nflexvert
+
+    // --- Metadata -----------------------------------------------------
+
+    /** MuJoCo simulation time at the moment of the snapshot. */
+    mjtNum SimTime = 0.0;
+
+    /** Monotonic frame counter. Incremented every successful push.
+     *  Consumers can skip on a stale snapshot via equality test. */
+    uint64 FrameId = 0;
+};

--- a/Source/URLab/Public/MuJoCo/Utils/MjBind.h
+++ b/Source/URLab/Public/MuJoCo/Utils/MjBind.h
@@ -565,38 +565,6 @@ struct BodyView {
         return MjUtils::MjToUERotation(xquat);
     }
 
-    /** @brief Applies a world-space force (Unreal units/direction) to this body. */
-    void ApplyForce(FVector UEForce) {
-        if (!xfrc_applied) return;
-        mjtNum MjForce[3];
-        MjUtils::UEToMjPosition(UEForce, MjForce); // This handles cm->m and Y-flip
-        xfrc_applied[3] += MjForce[0];
-        xfrc_applied[4] += MjForce[1];
-        xfrc_applied[5] += MjForce[2];
-    }
-
-    /** @brief Applies a world-space wrench (Force and Torque) to this body. */
-    void ApplyWrench(FVector UEForce, FVector UETorque) {
-        if (!xfrc_applied) return;
-        
-        // Force: Convert and add to indices 3, 4, 5
-        mjtNum MjForce[3];
-        MjUtils::UEToMjPosition(UEForce, MjForce);
-        xfrc_applied[3] += MjForce[0];
-        xfrc_applied[4] += MjForce[1];
-        xfrc_applied[5] += MjForce[2];
-
-        // Torque: Convert and add to indices 0, 1, 2
-        // Note: Torque doesn't require the 0.01 scale factor (cm->m) in the same way, 
-        // but it does require the Y-flip and coordinate mapping.
-        // UEToMjRotation handles the flip/mapping part if treated as a vector.
-        // However, torque is often just a vector. 
-        // Looking at UMjBody::ApplyForce, it uses Torque.X, -Torque.Y, Torque.Z.
-        xfrc_applied[0] += (mjtNum)UETorque.X;
-        xfrc_applied[1] += (mjtNum)-UETorque.Y;
-        xfrc_applied[2] += (mjtNum)UETorque.Z;
-    }
-
     // Traversal Methods (Declared here, Implemented at the bottom)
     TArray<BodyView> Bodies() const;
     TArray<GeomView> Geoms() const;


### PR DESCRIPTION
## Summary

- New `FMjRenderSnapshot` is published by the physics thread once per step inside the existing `CallbackMutex` scope; game-thread consumers read it through `UMjPhysicsEngine::WithRenderState`, which briefly holds a separate `RenderStateMutex` for the duration of the visitor.
- `AAMjManager::Tick` now iterates every articulation + quick-convert component inside one visitor call, so every body in a single UE frame sees one coherent physics frame and multi-segment articulations no longer visibly desync.
- New command queue on `UMjPhysicsEngine` (`SubmitMocapPose`, `SubmitWrench`, `SubmitClearForce`) drains inside `CallbackMutex` right before `mj_step`. `Wake` / `PutToSleep` keep their synchronous one-shot contract via `ApplyWakeBody` / `ApplySleepBody`.
- `UMjFlexcomp::UpdateProceduralMesh` switches from a `FScopeTryLock` on `CallbackMutex` to `WithRenderState`, removing the occasional skipped-frame hitch when the physics thread was stepping. `UMjGeom::UpdateGlobalTransform` / `GetWorldLocation` likewise read through the snapshot.
- Drops dead `m_MocapPos` / `m_MocapQuat` on `UMjBody`, never-wired `MocapPos` / `MocapQuat` on `UMjQuickConvertComponent`, and unused `BodyView::ApplyForce` / `ApplyWrench`. `bDrivenByUnreal` on quick-convert now actually drives the body via `SubmitMocapPose`.

## Motivation

Each `UMjBody` ticked independently and read `m_BodyView.xpos` / `xquat` lock-free, so two bodies attached to the same articulation could sample two different physics frames in one render frame. Visually this showed up as articulations breaking pose mid-motion. Mocap and `xfrc_applied` writes were also racing the integrator without a lock. The render-state snapshot + command queue removes both classes of race with a single lock-ordering story: `CallbackMutex` (outer), `RenderStateMutex` (inner); `CommandMutex` independent.

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-06-13 19:04:28 UTC
Git HEAD  : 145331c8 (feat/render-state-pump)
Engine    : UE_5.7
Deps      : mj=6882095 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 206 / 206 passed (0 failed)  [206 tests performed]
Log sha256: bf3e2f9e5a115d30
================================
```

## Manual verification steps

- Open any multi-body articulation (Franka Panda or the G1 humanoid are good stress tests) and confirm under PIE that the bodies stay coherent across the chain even at high `SimSpeedPercent`. Before this change the arm visibly kinks; after it the chain stays rigid.
- Spawn a mocap body and drag its UE actor: the simulated `mocap_pos` follows without dropping frames.
- Hit a Blueprint-bound `ApplyForce` or `ClearForce` while the sim is running and confirm the queue applies it next step.
- Toggle `Wake` / `PutToSleep` from Blueprint and confirm `IsAwake` reflects the new value immediately.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes
- [ ] Docs updated for user-facing changes