### PR TITLE
docs: pin supported engine to UE 5.7 and link UE GitHub source

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ ROS 2 bridging.
 
 ## Requirements
 
-- Unreal Engine 5.7+, Windows (Win64) with Visual Studio 2022/2025, or Linux
+- Unreal Engine 5.7 (only tested/supported version; avoid 5.8 — Vulkan driver
+  regressions on Linux), Windows (Win64) with Visual Studio 2022/2025, or Linux
   (x86_64) with UE's bundled clang.
 - CMake 3.24+ to build the dependencies.
 - MuJoCo, CoACD, and libzmq are bundled as submodules and built from source.

--- a/docs/contributing/building.md
+++ b/docs/contributing/building.md
@@ -90,7 +90,7 @@ A missing DLL almost always means `build_all` was never run, so `third_party/ins
 
 ## Linux build internals
 
-URLab builds on Linux against UE 5.7+, but the flow is more involved than on Windows because UE's bundled clang and libc++ require the native deps to be ABI-compatible. The [Installation](../installation.md) page covers the one-time walkthrough; this section documents the internals you may need when debugging a per-dep failure.
+URLab builds on Linux against UE 5.7 (the only supported version — avoid 5.8 due to Vulkan driver regressions), but the flow is more involved than on Windows because UE's bundled clang and libc++ require the native deps to be ABI-compatible. The [Installation](../installation.md) page covers the one-time walkthrough; this section documents the internals you may need when debugging a per-dep failure.
 
 ### Why `--engine`
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,9 +8,11 @@ page follows.
 
 **Before you start, you will need:**
 
-- **Unreal Engine 5.7+.** The plugin code builds on earlier UE5 versions, but the
-  bundled assets (dashboard UI, materials, input mappings) were saved in 5.7 and
-  do not load on older versions.
+- **Unreal Engine 5.7.** This is the only tested and supported version. The
+  plugin code builds on earlier UE5 versions, but the bundled assets (dashboard
+  UI, materials, input mappings) were saved in 5.7 and do not load on older
+  versions. **Avoid 5.8 for now** — it has regressions with the Vulkan drivers on
+  Linux that break rendering; stay on 5.7 until that is resolved.
 - **CMake 3.24+** to build URLab's native dependencies (MuJoCo, CoACD, libzmq).
 - **Python 3.11+** (optional), only if you drive URLab from Python.
 
@@ -23,15 +25,21 @@ page follows.
 
 === "Windows"
 
-    Install Unreal Engine 5.7 or newer through the Epic Games Launcher. You also
+    Install Unreal Engine 5.7 through the Epic Games Launcher. You also
     need **Visual Studio 2022 (17.10+) or 2025**, or **JetBrains Rider**, with the
     *Game development with C++* workload, to compile the plugin.
 
 === "Linux"
 
-    Download the precompiled Linux engine from your Epic account at
-    <https://www.unrealengine.com/linux> and extract it. This guide refers to the
-    extract root as `$UE_ROOT`.
+    Download the precompiled **Unreal Engine 5.7** Linux engine from your Epic
+    account at <https://www.unrealengine.com/linux> and extract it. This guide
+    refers to the extract root as `$UE_ROOT`.
+
+    Alternatively, build from source via the
+    [EpicGames/UnrealEngine](https://github.com/EpicGames/UnrealEngine) GitHub
+    repository (checkout the `5.7` branch). Access requires
+    [linking your Epic and GitHub accounts](https://www.unrealengine.com/en-US/ue-on-github).
+    Do not use the `5.8` or `release` branches — see the version note above.
 
     !!! warning "The precompiled Linux engine omits some build scripts"
         As of UE 5.7.4 the Linux binary does not ship


### PR DESCRIPTION
## Summary

- Pin all "Unreal Engine 5.7+" references to **5.7 only** (README, installation guide, building guide) and add an explicit warning against 5.8.
- Add the [EpicGames/UnrealEngine](https://github.com/EpicGames/UnrealEngine) GitHub source path as an alternative to the precompiled binary in the Linux install section, including the Epic↔GitHub account-linking note.

## Motivation

UE 5.8 was just released and has regressions with the Vulkan drivers on Linux that break rendering. The docs previously advertised "5.7+", which incorrectly implies 5.8 is supported. Pinning to 5.7 matches what is actually tested (and is consistent with `troubleshooting.md`, which already states 5.7 is the only supported version). The GitHub source link gives Linux users a documented alternative to the precompiled binary.

## Linked issue

Related to #

## Build + test evidence

Docs-only change — no code touched, so no build/test run is required.

## Manual verification steps

- Render the docs (or read the diff) and confirm:
  - `docs/installation.md`, `docs/contributing/building.md`, and `README.md` no longer say "5.7+" / "5.7 or newer".
  - The 5.8 / Vulkan warning reads clearly.
  - The Linux install section links to the UE GitHub repo and the account-linking page.

## Checklist

- [ ] Builds locally against UE 5.7+ — N/A (docs-only)
- [x] Full `URLab.*` automation suite passes — N/A (docs-only)
- [x] Docs updated for user-facing changes