### PR TITLE
fix(sim): pace live mode off resolved step mode (Auto->Live)

### DIFF
--- a/Source/URLab/Private/Bridge/RpcDispatcher.cpp
+++ b/Source/URLab/Private/Bridge/RpcDispatcher.cpp
@@ -273,6 +273,9 @@ void FURLabRpcDispatcher::Init(AAMjManager* InManager)
 								 ? EStepMode::Live
 								 : OwnerMgr->StepMode;
 	ActiveStepMode.store(InitMode, std::memory_order_release);
+	// Mirror onto the manager so the physics loop paces off the resolved mode
+	// (Auto -> Live), not the configured StepMode which would stay Auto.
+	OwnerMgr->EffectiveStepMode.store(InitMode, std::memory_order_release);
 	const bool bPaused = (InitMode != EStepMode::Live);
 	OwnerMgr->bPublishersPaused.store(bPaused, std::memory_order_release);
 	FCameraZmqWorker::bPublishersPaused.store(bPaused, std::memory_order_release);
@@ -1942,6 +1945,7 @@ void FURLabRpcDispatcher::SetActiveStepMode(EStepMode NewMode)
 	DrainQueuesForTest();
 
 	ActiveStepMode.store(NewMode, std::memory_order_release);
+	Mgr->EffectiveStepMode.store(NewMode, std::memory_order_release);
 	const bool bPaused = (NewMode != EStepMode::Live);
 	Mgr->bPublishersPaused.store(bPaused, std::memory_order_release);
 	FCameraZmqWorker::bPublishersPaused.store(bPaused, std::memory_order_release);

--- a/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
+++ b/Source/URLab/Private/MuJoCo/Core/MjPhysicsEngine.cpp
@@ -474,7 +474,7 @@ void UMjPhysicsEngine::RunMujocoAsync()
 				bool bSkipApplyControls = false;
 				if (AAMjManager* OwnerMgr = Cast<AAMjManager>(GetOwner()))
 				{
-					bSkipApplyControls = (OwnerMgr->StepMode == EStepMode::Puppet);
+					bSkipApplyControls = (OwnerMgr->EffectiveStepMode.load(std::memory_order_acquire) == EStepMode::Puppet);
 				}
 				if (!bSkipApplyControls)
 				{
@@ -523,7 +523,10 @@ void UMjPhysicsEngine::RunMujocoAsync()
 			bool bUseRealTimePacing = true;
 			if (AAMjManager* OwnerMgr = Cast<AAMjManager>(GetOwner()))
 			{
-				bUseRealTimePacing = (OwnerMgr->StepMode == EStepMode::Live);
+				// Pace off the resolved mode, not the configured StepMode (which
+				// defaults to Auto). Auto resolves to Live, so a freshly-started
+				// live session runs real-time instead of blocking at ~10 Hz.
+				bUseRealTimePacing = (OwnerMgr->EffectiveStepMode.load(std::memory_order_acquire) == EStepMode::Live);
 			}
 			if (bUseRealTimePacing)
 			{

--- a/Source/URLab/Public/MuJoCo/Core/AMjManager.h
+++ b/Source/URLab/Public/MuJoCo/Core/AMjManager.h
@@ -176,6 +176,19 @@ public:
 	 */
 	std::atomic<bool> bPublishersPaused{false};
 
+	/**
+	 * @brief The resolved, authoritative step mode the physics loop runs under.
+	 *
+	 * `StepMode` above is the *configured* value and may be `Auto`, which the
+	 * dispatcher resolves to a concrete mode (Auto starts Live). The physics
+	 * loop must pace off the resolved mode, not the configured one — reading
+	 * `StepMode == Live` directly leaves `Auto` (the default) pacing as if it
+	 * were Direct, blocking on the step-request timeout at ~10 Hz. The
+	 * dispatcher mirrors its `ActiveStepMode` here whenever it changes; defaults
+	 * to Live so a bridge-less PIE session runs real-time.
+	 */
+	std::atomic<EStepMode> EffectiveStepMode{EStepMode::Live};
+
 	/** Owns the FURLabRpcDispatcher + transports. Created in BeginPlay, destroyed in EndPlay. */
 	UPROPERTY()
 	TObjectPtr<UURLabBridgeServer> BridgeServer;

--- a/Source/URLabEditor/Private/Tests/MjStepServerTests.cpp
+++ b/Source/URLabEditor/Private/Tests/MjStepServerTests.cpp
@@ -280,6 +280,56 @@ bool FMjStepServerPauseFlag::RunTest(const FString& Parameters)
 }
 
 // ---------------------------------------------------------------------------
+// 1b. EffectiveStepMode mirrors the resolved mode (regression: live 10 Hz lock)
+//     The physics loop paces off Manager->EffectiveStepMode. StepMode defaults
+//     to Auto; if that does not resolve to Live the loop falls into the
+//     step-request wait path and ticks at the 100 ms timeout (~10 Hz) instead
+//     of running real-time.
+// ---------------------------------------------------------------------------
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjStepServerEffectiveMode,
+	"URLab.StepServer.EffectiveStepMode",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMjStepServerEffectiveMode::RunTest(const FString& Parameters)
+{
+	FMjUESession S;
+	if (!S.Init())
+	{
+		AddError(S.LastError);
+		return false;
+	}
+
+	// StepMode is Auto by default; RegisterManager must resolve+mirror it to Live.
+	TestEqual(TEXT("configured StepMode is Auto"),
+		(int)S.Manager->StepMode, (int)EStepMode::Auto);
+	TestEqual(TEXT("EffectiveStepMode resolves Auto -> Live"),
+		(int)S.Manager->EffectiveStepMode.load(), (int)EStepMode::Live);
+
+	FURLabRpcDispatcher* Disp = S.Manager->GetStepDispatcher();
+	if (!Disp)
+	{
+		AddError(TEXT("Manager has no StepDispatcher"));
+		S.Cleanup();
+		return false;
+	}
+
+	Disp->SetActiveStepMode(EStepMode::Direct);
+	TestEqual(TEXT("EffectiveStepMode tracks Direct"),
+		(int)S.Manager->EffectiveStepMode.load(), (int)EStepMode::Direct);
+
+	Disp->SetActiveStepMode(EStepMode::Puppet);
+	TestEqual(TEXT("EffectiveStepMode tracks Puppet"),
+		(int)S.Manager->EffectiveStepMode.load(), (int)EStepMode::Puppet);
+
+	Disp->SetActiveStepMode(EStepMode::Live);
+	TestEqual(TEXT("EffectiveStepMode tracks Live"),
+		(int)S.Manager->EffectiveStepMode.load(), (int)EStepMode::Live);
+
+	S.Cleanup();
+	return true;
+}
+
+// ---------------------------------------------------------------------------
 // 2. UMjPDController ApplyConfig round-trip
 // ---------------------------------------------------------------------------
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FMjStepServerControllerConfig,


### PR DESCRIPTION
## Summary

- Live (and Auto) sessions ran at ~10 Hz instead of real time. The physics loop paced off `Manager->StepMode`, which defaults to `Auto` and is never set to `Live` at runtime, so it fell into the Direct/Puppet step-request wait path (100 ms timeout = ~10 Hz).
- Mirror the dispatcher's resolved `ActiveStepMode` onto the manager as `EffectiveStepMode` and pace (and gate the puppet apply-controls skip) off that.

## Motivation

`EStepMode::Auto` is documented to "start Live", and the dispatcher resolves Auto to Live in its own `ActiveStepMode`. But the physics loop read the configured `Manager->StepMode` (still `Auto`), so `bUseRealTimePacing = (StepMode == Live)` was false and the loop blocked on `StepRequestEvent->Wait(100)`. A fresh live/PIE session therefore stepped at ~10 Hz until something switched the mode. The same stale read made the Puppet apply-controls skip miss in Auto-resolved-Puppet.

## Linked issue

Related to # (live-mode 10 Hz stepping)

## Build + test evidence

```
=== URLab build+test summary ===
Timestamp : 2026-06-24 20:48:12 UTC
Git HEAD  : 6abefea2 (fix/live-mode-step-pacing, base; this change applied on top)
Engine    : UE_5.7
Deps      : mj=67a1ea6 coacd=c7436bf zmq=7d95ac0
Build     : Succeeded
Tests     : 261 / 261 passed (0 failed)  [261 tests performed]
Log sha256: 93758019dc040be6
================================
```

New `URLab.StepServer.EffectiveStepMode` asserts `Auto` resolves+mirrors to `Live` and tracks Direct/Puppet/Live switches.

## Manual verification steps

1. Open a level with an `AMjManager` (StepMode left at Auto) and a moving model, press PIE.
2. Expect: the sim advances at real time immediately, without needing a streaming/mode RPC to kick it into Live.

## Checklist

- [x] Builds locally against UE 5.7+
- [x] Full `URLab.*` automation suite passes
- [x] Docs updated for user-facing changes (n/a)
